### PR TITLE
test: make the web weekly loop a canonical release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,26 @@ jobs:
 
       - name: Build server
         run: npm run build:server
+
+  canonical-e2e:
+    name: web / canonical-e2e
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run canonical browser journey
+        run: npm run test:e2e
+
+      - name: Remove synthetic fixtures
+        if: always()
+        run: rm -rf test-results/canonical

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ Default local endpoints:
 ## Verification
 
 - unit and integration tests: `npm run test`
-- authoritative Electron release smoke: `npm run test:e2e`
-- advisory browser placeholders only: `npm run test:e2e:advisory`
+- authoritative web browser journey: `npm run test:e2e`
+- advisory Electron smoke: `npm run test:e2e:electron-advisory`
+- advisory broad browser placeholders: `npm run test:e2e:advisory`
 - type check: `npm run typecheck`
 - lint: `npm run lint`
 
@@ -79,12 +80,14 @@ The release-verification ladder and the distinction between authoritative versus
 - Canonical package manager is `npm`.
 - The only accepted lockfile is `package-lock.json`.
 - CI must install dependencies with `npm ci` (frozen lockfile behavior).
-- Merge readiness is determined by the `quality-gate` check, which runs:
+- Merge readiness is determined by `web / static-and-unit` and `web / canonical-e2e`.
+- `web / static-and-unit` runs:
   - `npm run typecheck`
   - `npm run lint`
   - `npm run test`
   - `npm run build`
-  - an advisory Electron smoke assertion (non-blocking): `npm run test:e2e -- --grep "desktop smoke: Life OS main window"`
+- `web / canonical-e2e` runs the built SPA through Express with `npm run test:e2e`.
+- Electron smoke remains advisory and separate from merge readiness.
 
 ## License
 

--- a/api/__tests__/auth.test.ts
+++ b/api/__tests__/auth.test.ts
@@ -20,6 +20,29 @@ describe('auth and invite access control', () => {
     await fs.rm(authFile, { force: true });
   });
 
+  it('uses the environment-selected auth file when no path is provided', async () => {
+    const previousPath = process.env.LIFEOS_AUTH_DATA_FILE;
+    process.env.LIFEOS_AUTH_DATA_FILE = authFile;
+
+    try {
+      const repository = new FileBackedAuthRepository(undefined, [
+        { email: 'env-partner@example.com', code: 'ENV-001' },
+      ]);
+
+      await repository.registerWithInvite({
+        email: 'env-partner@example.com',
+        passwordHash: 'synthetic-hash',
+        fullName: 'Environment Partner',
+        inviteCode: 'ENV-001',
+      });
+
+      await expect(fs.stat(authFile)).resolves.toBeDefined();
+    } finally {
+      if (previousPath === undefined) delete process.env.LIFEOS_AUTH_DATA_FILE;
+      else process.env.LIFEOS_AUTH_DATA_FILE = previousPath;
+    }
+  });
+
   it('blocks unauthenticated MVP access and only allows invited registration', async () => {
     const app = createApp(
       new FileBackedMvpRepository(mvpFile),

--- a/api/__tests__/static.test.ts
+++ b/api/__tests__/static.test.ts
@@ -28,6 +28,7 @@ describe('static SPA routing', () => {
     const root = await request(app).get('/');
     expect(root.status).toBe(200);
     expect(root.text).toContain(marker);
+    expect(root.headers['content-security-policy']).not.toContain('upgrade-insecure-requests');
 
     const clientRoute = await request(app).get('/mvp/today');
     expect(clientRoute.status).toBe(200);

--- a/api/app.ts
+++ b/api/app.ts
@@ -114,7 +114,13 @@ export function createApp(
       credentials: true,
     })
   );
-  app.use(helmet());
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: { upgradeInsecureRequests: null },
+      },
+    })
+  );
   app.use(cookieParser());
   app.use(express.json());
 

--- a/api/authRepository.ts
+++ b/api/authRepository.ts
@@ -30,7 +30,7 @@ interface AuthState {
 }
 
 function defaultFilePath() {
-  return path.join(process.cwd(), '.data', 'auth-state.json');
+  return process.env.LIFEOS_AUTH_DATA_FILE || path.join(process.cwd(), '.data', 'auth-state.json');
 }
 
 function normalizeEmail(email: string) {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test:watch": "vitest",
     "test:integration": "vitest run src/features/**/__tests__/*.int.test.tsx",
     "test:e2e": "playwright test -c playwright.release.config.ts",
-    "test:e2e:smoke": "playwright test -c playwright.release.config.ts",
+    "test:e2e:electron-advisory": "playwright test -c playwright.electron.config.ts",
     "test:e2e:advisory": "playwright test -c playwright.config.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate:dev": "prisma migrate dev",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,17 +19,17 @@ export default defineConfig({
     {
       name: 'advisory-chromium',
       use: { ...devices['Desktop Chrome'] },
-      testIgnore: ['**/smoke.spec.ts'],
+      testIgnore: ['**/smoke.spec.ts', '**/canonical.spec.ts'],
     },
     {
       name: 'advisory-firefox',
       use: { ...devices['Desktop Firefox'] },
-      testIgnore: ['**/smoke.spec.ts'],
+      testIgnore: ['**/smoke.spec.ts', '**/canonical.spec.ts'],
     },
     {
       name: 'advisory-webkit',
       use: { ...devices['Desktop Safari'] },
-      testIgnore: ['**/smoke.spec.ts'],
+      testIgnore: ['**/smoke.spec.ts', '**/canonical.spec.ts'],
     },
   ],
 })

--- a/playwright.electron.config.ts
+++ b/playwright.electron.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 45_000,
+  testMatch: '**/smoke.spec.ts',
+  use: {
+    headless: true,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'advisory-electron' }],
+})

--- a/playwright.release.config.ts
+++ b/playwright.release.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   testDir: './tests/e2e',
   timeout: 120_000,
   testMatch: '**/canonical.spec.ts',
+  outputDir: 'test-results/canonical/playwright',
   workers: 1,
   retries: process.env.CI ? 1 : 0,
   use: {

--- a/playwright.release.config.ts
+++ b/playwright.release.config.ts
@@ -1,16 +1,49 @@
-import { defineConfig } from '@playwright/test'
+import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({
   testDir: './tests/e2e',
-  timeout: 45_000,
-  testMatch: '**/smoke.spec.ts',
+  timeout: 120_000,
+  testMatch: '**/canonical.spec.ts',
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
   use: {
+    baseURL: 'http://app.lifeos.test:3001',
     headless: true,
     trace: 'on-first-retry',
   },
+  webServer: {
+    command:
+      'rm -rf test-results/canonical && mkdir -p test-results/canonical && npm run build && npm run build:server && node dist-server/api/server.js',
+    url: 'http://127.0.0.1:3001/api/health',
+    reuseExistingServer: false,
+    timeout: 240_000,
+    env: {
+      LIFEOS_SESSION_SECRET: 'canonical-e2e-synthetic-secret',
+      LIFEOS_MVP_REPOSITORY: 'file',
+      LIFEOS_AUTH_DATA_FILE: 'test-results/canonical/auth-state.json',
+      MVP_DATA_FILE: 'test-results/canonical/mvp-workspace.json',
+      ALLOWED_ORIGIN: 'http://app.lifeos.test:3001',
+      LIFEOS_INVITES: JSON.stringify([
+        { email: 'canonical-a@example.test', code: 'INVITE-A' },
+        { email: 'canonical-b@example.test', code: 'INVITE-B' },
+      ]),
+    },
+  },
   projects: [
     {
-      name: 'smoke',
+      name: 'canonical-chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          ...(process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+            ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH }
+            : {}),
+          args: [
+            '--host-resolver-rules=MAP app.lifeos.test 127.0.0.1',
+            '--no-proxy-server',
+          ],
+        },
+      },
     },
   ],
 })

--- a/src/shared/lib/__tests__/releaseGate.test.ts
+++ b/src/shared/lib/__tests__/releaseGate.test.ts
@@ -64,6 +64,7 @@ describe('release gate contract', () => {
     const releaseProjects = (releasePlaywrightConfig.projects ?? []) as Array<{ name?: string }>
 
     expect(releasePlaywrightConfig.testMatch).toBe('**/canonical.spec.ts')
+    expect(releasePlaywrightConfig.outputDir).toBe('test-results/canonical/playwright')
     expect(releasePlaywrightConfig.webServer).toBeDefined()
     expect(releaseProjects.map((project) => project.name)).toEqual(['canonical-chromium'])
   })

--- a/src/shared/lib/__tests__/releaseGate.test.ts
+++ b/src/shared/lib/__tests__/releaseGate.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs'
 
 import advisoryPlaywrightConfig from '../../../../playwright.config'
+import electronPlaywrightConfig from '../../../../playwright.electron.config'
 import releasePlaywrightConfig from '../../../../playwright.release.config'
 
 function readPackageJsonScripts() {
@@ -14,6 +15,7 @@ function readPackageJsonScripts() {
 describe('release gate contract', () => {
   it('uses one honest web static-and-unit workflow', () => {
     const workflow = readFileSync(`${process.cwd()}/.github/workflows/ci.yml`, 'utf8')
+    const staticJob = workflow.split(/^ {2}canonical-e2e:/m)[0]
 
     expect(workflow).toContain('name: Web CI')
     expect(workflow).toContain('name: web / static-and-unit')
@@ -22,8 +24,17 @@ describe('release gate contract', () => {
     expect(workflow).toContain('npm run test')
     expect(workflow).toContain('npm run build')
     expect(workflow).toContain('npm run build:server')
-    expect(workflow).not.toContain('electron:build')
-    expect(workflow).not.toContain('test:e2e')
+    expect(staticJob).not.toContain('electron:build')
+    expect(staticJob).not.toContain('test:e2e')
+  })
+
+  it('publishes canonical browser evidence as a separate stable job', () => {
+    const workflow = readFileSync(`${process.cwd()}/.github/workflows/ci.yml`, 'utf8')
+
+    expect(workflow).toContain('name: web / canonical-e2e')
+    expect(workflow).toContain('npx playwright install --with-deps chromium')
+    expect(workflow).toContain('npm run test:e2e')
+    expect(workflow).toMatch(/if:\s*always\(\)[\s\S]*rm -rf test-results\/canonical/)
   })
 
   it('removes duplicate generic-test and false-RLS workflow ownership', () => {
@@ -35,16 +46,26 @@ describe('release gate contract', () => {
     const scripts = readPackageJsonScripts()
 
     expect(scripts['test:e2e']).toBe('playwright test -c playwright.release.config.ts')
-    expect(scripts['test:e2e:smoke']).toBe('playwright test -c playwright.release.config.ts')
+    expect(scripts['test:e2e:electron-advisory']).toBe(
+      'playwright test -c playwright.electron.config.ts',
+    )
     expect(scripts['test:e2e:advisory']).toBe('playwright test -c playwright.config.ts')
   })
 
   it('keeps the experimental Electron config smoke-only and browser-free', () => {
+    const electronProjects = (electronPlaywrightConfig.projects ?? []) as Array<{ name?: string }>
+
+    expect(electronPlaywrightConfig.testMatch).toBe('**/smoke.spec.ts')
+    expect(electronPlaywrightConfig.webServer).toBeUndefined()
+    expect(electronProjects.map((project) => project.name)).toEqual(['advisory-electron'])
+  })
+
+  it('owns the canonical browser journey in one Chromium project', () => {
     const releaseProjects = (releasePlaywrightConfig.projects ?? []) as Array<{ name?: string }>
 
-    expect(releasePlaywrightConfig.testMatch).toBe('**/smoke.spec.ts')
-    expect(releasePlaywrightConfig.webServer).toBeUndefined()
-    expect(releaseProjects.map((project) => project.name)).toEqual(['smoke'])
+    expect(releasePlaywrightConfig.testMatch).toBe('**/canonical.spec.ts')
+    expect(releasePlaywrightConfig.webServer).toBeDefined()
+    expect(releaseProjects.map((project) => project.name)).toEqual(['canonical-chromium'])
   })
 
   it('labels browser projects as advisory and keeps smoke out of that lane', () => {
@@ -60,6 +81,11 @@ describe('release gate contract', () => {
     ).toBe(true)
     expect(
       advisoryProjects.every((project) => project.testIgnore?.includes('**/smoke.spec.ts') === true),
+    ).toBe(true)
+    expect(
+      advisoryProjects.every(
+        (project) => project.testIgnore?.includes('**/canonical.spec.ts') === true,
+      ),
     ).toBe(true)
   })
 

--- a/tests/e2e/canonical.spec.ts
+++ b/tests/e2e/canonical.spec.ts
@@ -183,6 +183,15 @@ test('invited weekly loop persists and isolates each user', async ({ browser, pl
     expect(secondWorkspace.plan.priorities).toEqual([])
     expect(JSON.stringify(secondWorkspace)).not.toContain(marker)
 
+    const foreignActionAttempt = await secondUserContext.patch(
+      `/api/mvp/action-items/${actionId}`,
+      { data: { status: 'deferred' } },
+    )
+    expect(foreignActionAttempt.status()).toBe(200)
+    const secondWorkspaceAfterAttempt = (await foreignActionAttempt.json()).data
+    expect(secondWorkspaceAfterAttempt.plan.priorities).toEqual([])
+    expect(JSON.stringify(secondWorkspaceAfterAttempt)).not.toContain(marker)
+
     const unchangedFirstResponse = await page.evaluate(async () => {
       const response = await fetch('/api/mvp/workspace', { credentials: 'include' })
       return { status: response.status, body: await response.json() }
@@ -193,9 +202,11 @@ test('invited weekly loop persists and isolates each user', async ({ browser, pl
     expect(JSON.stringify(unchangedFirst)).toContain(`${marker}-reflection`)
     expect(JSON.stringify(unchangedFirst)).toContain(`${marker}-feedback`)
   } finally {
-    await secondUserContext?.dispose()
-    await userContext?.close()
-    await registrationContext?.close()
+    await Promise.allSettled([
+      secondUserContext?.dispose(),
+      userContext?.close(),
+      registrationContext?.close(),
+    ])
     await Promise.all([
       rm('test-results/canonical/auth-state.json', { force: true }),
       rm('test-results/canonical/mvp-workspace.json', { force: true }),

--- a/tests/e2e/canonical.spec.ts
+++ b/tests/e2e/canonical.spec.ts
@@ -1,0 +1,204 @@
+import { expect, test } from '@playwright/test'
+import { rm } from 'node:fs/promises'
+
+const apiBase = 'http://127.0.0.1:3001'
+const password = 'Canonical123!'
+const marker = 'canonical-a'
+
+test('invited weekly loop persists and isolates each user', async ({ browser, playwright, request }) => {
+  let registrationContext: Awaited<ReturnType<typeof browser.newContext>> | undefined
+  let userContext: Awaited<ReturnType<typeof browser.newContext>> | undefined
+  let secondUserContext: Awaited<ReturnType<typeof playwright.request.newContext>> | undefined
+
+  try {
+    expect((await request.get(`${apiBase}/api/mvp/workspace`)).status()).toBe(401)
+
+    const stolenInvite = await request.post(`${apiBase}/api/auth/register`, {
+      data: {
+        email: 'attacker@example.test',
+        password,
+        name: 'Attacker',
+        inviteCode: 'INVITE-A',
+      },
+    })
+    expect(stolenInvite.ok()).toBe(false)
+
+    registrationContext = await browser.newContext({ baseURL: 'http://app.lifeos.test:3001' })
+    await registrationContext.addInitScript(() => {
+      localStorage.setItem('life-os-onboarding-completed', 'true')
+    })
+    const registrationPage = await registrationContext.newPage()
+    await registrationPage.goto('/register')
+    await registrationPage.getByPlaceholder('Nome', { exact: true }).fill('Canonical')
+    await registrationPage.getByPlaceholder('Sobrenome').fill('A')
+    await registrationPage.getByPlaceholder('seu@email.com').fill('canonical-a@example.test')
+    await registrationPage.getByPlaceholder('LIFEOS-INVITE').fill('INVITE-A')
+    await registrationPage.getByPlaceholder('••••••••').nth(0).fill(password)
+    await registrationPage.getByPlaceholder('••••••••').nth(1).fill(password)
+    const registrationResponse = registrationPage.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === '/api/auth/register' &&
+        response.request().method() === 'POST',
+    )
+    await registrationPage.getByRole('button', { name: 'CRIAR CONTA' }).click()
+    expect((await registrationResponse).status()).toBe(201)
+    await registrationPage.waitForURL(/\/mvp$/)
+    await registrationContext.close()
+    registrationContext = undefined
+
+    userContext = await browser.newContext({ baseURL: 'http://app.lifeos.test:3001' })
+    await userContext.addInitScript(() => {
+      localStorage.setItem('life-os-onboarding-completed', 'true')
+    })
+    const page = await userContext.newPage()
+    await page.goto('/login')
+    await page.getByTestId('login-email-input').fill('canonical-a@example.test')
+    await page.getByTestId('login-password-input').fill(password)
+    const loginResponse = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === '/api/auth/login' &&
+        response.request().method() === 'POST',
+    )
+    await page.getByTestId('login-submit-button').click()
+    expect((await loginResponse).status()).toBe(200)
+    await page.waitForURL(/\/mvp$/)
+
+    await page.goto('/mvp/onboarding')
+    await expect(page).toHaveURL(/\/mvp\/onboarding$/, { timeout: 10_000 })
+    await expect
+      .poll(() => page.locator('body').innerText(), { timeout: 10_000 })
+      .toContain('Onboarding intake')
+    await expect(page.getByRole('heading', { name: 'Onboarding intake' })).toBeVisible({
+      timeout: 10_000,
+    })
+    await page.getByPlaceholder('Display name').fill(`${marker}-display`)
+    await page.getByPlaceholder('Role').fill(`${marker}-role`)
+    await page.getByPlaceholder('Life season').fill(`${marker}-season`)
+    await page.getByPlaceholder('Success definition for this season').fill(`${marker}-success`)
+    await page
+      .getByPlaceholder('What is breaking in the current planning system?')
+      .fill(`${marker}-pain`)
+    await page.getByPlaceholder('Goals, one per line').fill(`${marker}-goal`)
+    await page.getByPlaceholder('Recurring commitments, one per line').fill(`${marker}-commitment`)
+    await page.getByPlaceholder('Constraints or realities, one per line').fill(`${marker}-constraint`)
+    const onboardingResponse = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === '/api/mvp/onboarding' &&
+        response.request().method() === 'PUT',
+    )
+    await page.getByRole('button', { name: 'Save intake' }).click()
+    expect((await onboardingResponse).ok()).toBe(true)
+
+    await page.goto('/mvp/weekly-review')
+    await page.getByPlaceholder('Primary focus area').fill(`${marker}-focus`)
+    await page.getByPlaceholder('Energy level 1-5').fill('4')
+    await page.getByPlaceholder('Wins from the previous cycle, one per line').fill(`${marker}-win`)
+    await page
+      .getByPlaceholder('Unfinished work still pulling attention, one per line')
+      .fill(`${marker}-unfinished`)
+    await page.getByPlaceholder('Constraints for this week, one per line').fill(`${marker}-week-constraint`)
+    await page.getByPlaceholder('Notes that should shape the plan').fill(`${marker}-plan-note`)
+    const generatedResponse = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === '/api/mvp/weekly-plans/generate' &&
+        response.request().method() === 'POST',
+    )
+    await page.getByRole('button', { name: 'Generate weekly plan' }).click()
+    const generated = await generatedResponse
+    expect(generated.ok()).toBe(true)
+    const generatedBody = await generated.json()
+    const actionId = generatedBody.data.plan.priorities[0].actions[0].id as string
+    const planId = generatedBody.data.plan.id as string
+
+    const confirmResponse = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === `/api/mvp/weekly-plans/${planId}/confirm` &&
+        response.request().method() === 'POST',
+    )
+    await page.getByRole('button', { name: 'Confirm weekly plan' }).click()
+    expect((await confirmResponse).ok()).toBe(true)
+
+    await page.goto('/mvp/today')
+    const actionResponse = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === `/api/mvp/action-items/${actionId}` &&
+        response.request().method() === 'PATCH',
+    )
+    await page.getByRole('button', { name: 'Complete' }).first().click()
+    expect((await actionResponse).ok()).toBe(true)
+    await page.getByPlaceholder('Blockers').fill(`${marker}-blockers`)
+    await page.getByPlaceholder('Execution note').fill(`${marker}-execution-note`)
+    const checkInResponse = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === '/api/mvp/daily-checkins' &&
+        response.request().method() === 'POST',
+    )
+    await page.getByRole('button', { name: 'Save daily check-in' }).click()
+    expect((await checkInResponse).ok()).toBe(true)
+
+    await page.goto('/mvp/reflection')
+    await page.getByPlaceholder('Daily reflection').fill(`${marker}-reflection`)
+    const reflectionResponse = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === '/api/mvp/reflections' &&
+        response.request().method() === 'POST',
+    )
+    await page.getByRole('button', { name: 'Save daily reflection' }).click()
+    expect((await reflectionResponse).ok()).toBe(true)
+    await page.getByPlaceholder('What created clarity or friction?').fill(`${marker}-feedback`)
+    const feedbackResponse = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === '/api/mvp/feedback' &&
+        response.request().method() === 'POST',
+    )
+    await page.getByRole('button', { name: 'Submit feedback' }).click()
+    expect((await feedbackResponse).ok()).toBe(true)
+
+    const firstWorkspaceResponse = await page.evaluate(async () => {
+      const response = await fetch('/api/mvp/workspace', { credentials: 'include' })
+      return { status: response.status, body: await response.json() }
+    })
+    expect(firstWorkspaceResponse.status).toBe(200)
+    const firstWorkspace = firstWorkspaceResponse.body.data
+    expect(firstWorkspace.onboarding.displayName).toBe(`${marker}-display`)
+    expect(firstWorkspace.plan.confirmedAt).toBeTruthy()
+    expect(firstWorkspace.plan.priorities[0].actions[0]).toMatchObject({ id: actionId, status: 'done' })
+    expect(firstWorkspace.dailyCheckIns[0].note).toBe(`${marker}-execution-note`)
+    expect(JSON.stringify(firstWorkspace)).toContain(`${marker}-reflection`)
+    expect(JSON.stringify(firstWorkspace)).toContain(`${marker}-feedback`)
+
+    secondUserContext = await playwright.request.newContext({ baseURL: apiBase })
+    const secondRegistration = await secondUserContext.post('/api/auth/register', {
+      data: {
+        email: 'canonical-b@example.test',
+        password,
+        name: 'Canonical B',
+        inviteCode: 'INVITE-B',
+      },
+    })
+    expect(secondRegistration.status()).toBe(201)
+    const secondWorkspaceResponse = await secondUserContext.get('/api/mvp/workspace')
+    expect(secondWorkspaceResponse.ok()).toBe(true)
+    const secondWorkspace = (await secondWorkspaceResponse.json()).data
+    expect(secondWorkspace.plan.priorities).toEqual([])
+    expect(JSON.stringify(secondWorkspace)).not.toContain(marker)
+
+    const unchangedFirstResponse = await page.evaluate(async () => {
+      const response = await fetch('/api/mvp/workspace', { credentials: 'include' })
+      return { status: response.status, body: await response.json() }
+    })
+    expect(unchangedFirstResponse.status).toBe(200)
+    const unchangedFirst = unchangedFirstResponse.body.data
+    expect(unchangedFirst.plan.priorities[0].actions[0]).toMatchObject({ id: actionId, status: 'done' })
+    expect(JSON.stringify(unchangedFirst)).toContain(`${marker}-reflection`)
+    expect(JSON.stringify(unchangedFirst)).toContain(`${marker}-feedback`)
+  } finally {
+    await secondUserContext?.dispose()
+    await userContext?.close()
+    await registrationContext?.close()
+    await Promise.all([
+      rm('test-results/canonical/auth-state.json', { force: true }),
+      rm('test-results/canonical/mvp-workspace.json', { force: true }),
+    ])
+  }
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig(({ mode }) => {
   const isElectronMode = mode === 'electron'
 
   return {
-    base: './',
+    base: isElectronMode ? './' : '/',
     plugins: [
       react(),
       ...(isElectronMode ? [electron({


### PR DESCRIPTION
## Problem

The supported Express web runtime had no authoritative browser evidence. The existing Playwright release config owned Electron smoke, while broad browser specs were advisory and skipped. Shallow HTTP checks also missed that non-local HTTP assets were upgraded to HTTPS and nested web routes resolved relative assets below `/mvp`.

Closes #114.

## Solution

- add one Chromium journey against the built SPA served by Express;
- cover invited registration, fresh-context login, onboarding, weekly plan generation/confirmation, action completion, daily check-in, reflection, and feedback;
- prove unauthenticated denial, stolen-invite rejection, and a hostile B-to-A action mutation with no cross-tenant effect;
- isolate two synthetic users and disposable auth/MVP files;
- keep Electron smoke and broad browser coverage advisory;
- publish a sibling stable check named `web / canonical-e2e`;
- use `/` as the web Vite base while retaining `./` for Electron;
- retain Helmet CSP while removing only `upgrade-insecure-requests`, which broke the authorized non-local HTTP test hostname.

## Scope

No dependency, schema, migration, Docker, production data, real credentials, or Electron behavior changed.

Foreign-ID HTTP status remains the current user-scoped 200 no-op contract. Explicit 403/404 semantics remain tracked by #108.

## Verification

- targeted auth/static/release contracts: 12 passed;
- full Vitest: 616 passed, 62 skipped;
- canonical E2E: repeated clean passes; final hostile-tenant run passed;
- typecheck: pass;
- lint: 0 errors, 9 pre-existing warnings;
- web and server builds: pass inside each E2E run;
- workflow YAML parse: pass;
- `git diff --check`: pass;
- independent final review: ready to merge, no remaining findings.

## Cleanup and rollback

All Playwright output and synthetic state live below `test-results/canonical`; test cleanup removes state even when context shutdown fails, and CI removes the entire directory with `if: always()`.

Rollback is a clean revert of commits `c00b711` and `6aa93fe`.