### PR TITLE
Authorize the admin surface at the server boundary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,5 +47,7 @@ UNSPLASH_SECRET_KEY=your_unsplash_secret_key_here
 JWT_SECRET=your_jwt_secret_here
 LIFEOS_SESSION_SECRET=your_lifeos_session_secret_here
 LIFEOS_INVITES=[{"email":"partner@example.com","code":"LIFEOS-INVITE","fullName":"Design Partner"}]
+# Optional comma-separated exact emails. Empty means no administrator is authorized.
+LIFEOS_ADMIN_EMAILS=
 VITE_ENABLE_INTERNAL_MVP_ADMIN=false
 VITE_BYPASS_MVP_INVITE_GATE=false

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Run the default app and API:
 LIFEOS_SESSION_SECRET="$(openssl rand -hex 32)" npm run dev
 ```
 
+The admin route is only presentation until the server authorizes the signed-in identity. To authorize exact accounts, set a comma-separated allowlist such as `LIFEOS_ADMIN_EMAILS=operator@example.com`. An empty or malformed allowlist denies every account; client flags, localhost, invite metadata, and Electron do not grant administrator authority.
+
 The development scripts select `LIFEOS_OPERATING_MODE=local-dev`. Direct builds must select it explicitly:
 
 ```bash

--- a/api/__tests__/admin.test.ts
+++ b/api/__tests__/admin.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import request from 'supertest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { createApp } from '../app'
+import { FileBackedAuthRepository } from '../authRepository'
+import { FileBackedMvpRepository } from '../mvpRepository'
+
+describe.sequential('server-authorized MVP admin overview', () => {
+  const mvpFile = path.join(os.tmpdir(), `lifeos-admin-mvp-${Date.now()}.json`)
+  const authFile = path.join(os.tmpdir(), `lifeos-admin-auth-${Date.now()}.json`)
+  const previousAdmins = process.env.LIFEOS_ADMIN_EMAILS
+
+  beforeEach(async () => {
+    process.env.LIFEOS_ADMIN_EMAILS = 'admin@example.test'
+    await fs.rm(mvpFile, { force: true })
+    await fs.rm(authFile, { force: true })
+  })
+
+  afterEach(async () => {
+    if (previousAdmins === undefined) delete process.env.LIFEOS_ADMIN_EMAILS
+    else process.env.LIFEOS_ADMIN_EMAILS = previousAdmins
+    await fs.rm(mvpFile, { force: true })
+    await fs.rm(authFile, { force: true })
+  })
+
+  function app(repository = new FileBackedMvpRepository(mvpFile)) {
+    return createApp(
+      repository,
+      new FileBackedAuthRepository(authFile, [
+        { email: 'admin@example.test', code: 'ADMIN-INVITE' },
+        { email: 'member@example.test', code: 'MEMBER-INVITE' },
+      ]),
+    )
+  }
+
+  async function register(client: ReturnType<typeof request.agent>, email: string, inviteCode: string) {
+    const response = await client.post('/api/auth/register').send({
+      email,
+      password: 'Password123!',
+      name: email.startsWith('admin') ? 'Admin' : 'Member',
+      inviteCode,
+    })
+    expect(response.status).toBe(201)
+    return response.body.user.id as string
+  }
+
+  it('denies unauthenticated and ordinary invited users', async () => {
+    const server = app()
+    expect((await request(server).get('/api/mvp/admin/overview')).status).toBe(401)
+
+    const member = request.agent(server)
+    await register(member, 'member@example.test', 'MEMBER-INVITE')
+    expect((await member.get('/api/mvp/admin/overview')).status).toBe(403)
+  })
+
+  it('returns only analytics, events, and feedback to an allowlisted administrator', async () => {
+    const repository = new FileBackedMvpRepository(mvpFile)
+    const admin = request.agent(app(repository))
+    const adminId = await register(admin, 'admin@example.test', 'ADMIN-INVITE')
+    await repository.submitFeedback(adminId, { rating: 4, message: 'Useful signal.' })
+    const overview = await admin.get('/api/mvp/admin/overview')
+
+    expect(overview.status).toBe(200)
+    expect(Object.keys(overview.body.data).sort()).toEqual(['analytics', 'events', 'feedback'])
+    expect(overview.body.data.feedback).toHaveLength(1)
+    expect(overview.body.data.events.map((event: { type: string }) => event.type)).toContain('user_feedback_submitted')
+  })
+
+  it('does not expose a destructive admin reset operation', async () => {
+    const admin = request.agent(app())
+    await register(admin, 'admin@example.test', 'ADMIN-INVITE')
+
+    expect((await admin.delete('/api/mvp/admin/overview')).status).toBe(404)
+  })
+})

--- a/api/app.ts
+++ b/api/app.ts
@@ -89,6 +89,15 @@ function clearSessionCookie(res: express.Response) {
   });
 }
 
+function isConfiguredAdministrator(email: string) {
+  const configuredEmails = (process.env.LIFEOS_ADMIN_EMAILS ?? '')
+    .split(',')
+    .map((candidate) => candidate.trim().toLowerCase())
+    .filter((candidate) => z.string().email().safeParse(candidate).success);
+
+  return configuredEmails.includes(email.trim().toLowerCase());
+}
+
 export function createApp(
   repository: MvpRepository = createDefaultMvpRepository(),
   authRepository: AuthRepository = new FileBackedAuthRepository(),
@@ -261,6 +270,20 @@ export function createApp(
       ok(res, await repository.getWorkspace(req.authUser!.id));
     } catch (error) {
       next(error);
+    }
+  });
+
+  app.get('/api/mvp/admin/overview', async (req: AuthenticatedRequest, res, next) => {
+    if (!isConfiguredAdministrator(req.authUser!.email)) {
+      return fail(res, 'Administrator access required', 403);
+    }
+
+    try {
+      const workspace = await repository.getWorkspace(req.authUser!.id);
+      const { analytics, events, feedback } = workspace;
+      return ok(res, { analytics, events, feedback });
+    } catch (error) {
+      return next(error);
     }
   });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - ALLOWED_ORIGIN=${ALLOWED_ORIGIN:?ALLOWED_ORIGIN is required}
       - LIFEOS_SESSION_SECRET=${LIFEOS_SESSION_SECRET:?LIFEOS_SESSION_SECRET is required}
       - LIFEOS_INVITES=${LIFEOS_INVITES:?LIFEOS_INVITES is required}
+      - LIFEOS_ADMIN_EMAILS=${LIFEOS_ADMIN_EMAILS:-}
       - LIFEOS_MVP_REPOSITORY=file
     volumes:
       - life-os-data:/app/.data

--- a/docs/mvp/canonical-mvp.md
+++ b/docs/mvp/canonical-mvp.md
@@ -1,7 +1,7 @@
 # LifeOS Canonical MVP
 
 Status: active source of truth
-Last updated: 2026-03-28
+Last updated: 2026-07-17
 Owner: Product Strategist
 
 ## Product Decision
@@ -45,6 +45,7 @@ Backend contract:
 - `/api/mvp/daily-checkins`
 - `/api/mvp/reflections`
 - `/api/mvp/feedback`
+- `/api/mvp/admin/overview`
 - `/api/mvp/workspace` `DELETE`
 
 ## Scope In
@@ -63,13 +64,13 @@ Backend contract:
 - claiming Electron is the current default product runtime
 - sync or cloud-readiness claims
 - calling the admin view partner-facing
-- partner-production rollout of `/mvp/admin` without role-based authorization
+- treating client route visibility, localhost, invite metadata, or a Vite flag as administrator authority
 
 ## Current Constraints
 
 - default navigation still centers the broader suite instead of the MVP loop
-- `/mvp/admin` is currently accepted for internal/local/dev use with non-role controls (environment, invite, and operator process controls)
-- role-based authorization is required before any partner-production `/mvp/admin` rollout
+- `/mvp/admin` data is server-authorized by exact authenticated email through `LIFEOS_ADMIN_EMAILS`; an empty allowlist denies everyone
+- the current endpoint exposes only the authorized account's analytics, events, and feedback; cross-user/cohort administration is not implemented
 - some MVP copy still overstates readiness
 - the repo still contains stale desktop-first release docs and broad-suite PRD artifacts
 

--- a/docs/mvp/route-map.md
+++ b/docs/mvp/route-map.md
@@ -18,8 +18,8 @@ This file documents the implemented route and API contract for the canonical MVP
   Purpose: save reflection and product feedback
 - `GET /mvp/admin`
   Purpose: internal analytics surface
-  Current state: accepted for internal/local/dev use via non-role controls (environment, invite, and operator process controls)
-  Production policy: role-based authorization is required before any partner-production rollout
+  Current state: client routing is only presentation; data loads from the server-authorized admin endpoint
+  Authorization: the authenticated email must exactly match `LIFEOS_ADMIN_EMAILS`
 
 ### Legacy broader-suite routes still present in the shell
 
@@ -70,6 +70,14 @@ These routes exist in `src/config/routes/index.tsx`, but they are not canonical 
 - `DELETE /api/mvp/workspace`
   Output: reset workspace state for the authenticated user
 
+### Internal administration
+
+- `GET /api/mvp/admin/overview`
+  Authorization: authenticated email must exactly match a valid comma-separated entry in `LIFEOS_ADMIN_EMAILS`
+  Output: the administrator's analytics, event stream, and feedback only
+  Failure: `401` without a valid session; `403` for authenticated non-administrators
+  Destructive operations: none; workspace reset remains a user-scoped endpoint pending the recovery controls tracked in #108
+
 ### Onboarding
 
 - `PUT /api/mvp/onboarding`
@@ -105,5 +113,5 @@ These routes exist in `src/config/routes/index.tsx`, but they are not canonical 
 ## Important Contract Notes
 
 - There is no implemented `POST /api/mvp/auth/invite/accept` endpoint. Invite acceptance currently happens through `POST /api/auth/register`.
-- There is no dedicated backend admin overview endpoint. The `/mvp/admin` surface currently reads from workspace state rather than a separate analytics API.
+- Development mode, localhost, Vite flags, invite metadata, and UI visibility never authorize the backend admin endpoint.
 - The route map should be treated as executable contract documentation, not as a proposal list. If a route is not implemented, do not document it here as current behavior.

--- a/docs/security/2026-07-16-operating-modes-threat-model.md
+++ b/docs/security/2026-07-16-operating-modes-threat-model.md
@@ -61,14 +61,14 @@ The invite grants the right to create one account for the matching email. Once r
 
 ### Client gates are presentation only
 
-`src/config/routes/access.ts` allows MVP UI access based on development mode, localhost, browser flags or user metadata. It allows the internal admin UI based on development mode, localhost or a browser flag. These conditions only show or route UI. They do not establish an administrator role, and the current Express API exposes no separate server-authorized admin contract.
+`src/config/routes/access.ts` allows MVP UI access based on development mode, localhost, browser flags or user metadata. It allows the internal admin UI based on development mode, localhost or a browser flag. These conditions only show or route UI. They do not establish an administrator role. `GET /api/mvp/admin/overview` separately requires a valid web session whose normalized email exactly matches a valid entry in `LIFEOS_ADMIN_EMAILS`; an empty or malformed allowlist denies all users.
 
 Therefore:
 
 - local UI bypasses are permitted only in local-dev;
 - controlled-demo may not use a build with bypass flags enabled;
 - partner-beta/public must reject such builds;
-- no admin capability is supported beyond local-dev until the server enforces a role or explicit admin allowlist on every privileged operation;
+- the only supported admin capability is the read-only overview authorized by the server allowlist; there is no admin reset or cross-user aggregation;
 - hiding the navigation item or route is never acceptance evidence for authorization.
 
 ### Electron identity
@@ -103,6 +103,7 @@ Unknown or contradictory environment configuration must fail closed. No producti
 | `LIFEOS_SESSION_SECRET` | required, throwaway | required, strong and unique | required, managed and rotatable | required, managed and rotatable |
 | `ALLOWED_ORIGIN` | optional loopback | required exact HTTPS origin | required exact HTTPS origin | required exact HTTPS origin(s) |
 | `LIFEOS_INVITES` | optional; known fallback allowed | required unique seeds | required managed lifecycle until replaced | self-service/managed policy required by new decision |
+| `LIFEOS_ADMIN_EMAILS` | optional; empty denies all | explicit exact emails if admin overview is used | replace or operationalize with managed role lifecycle | managed least-privilege roles required by new decision |
 | bypass/admin Vite flags | may be true | must be absent/false | must be absent/false | must be absent/false |
 | `LIFEOS_MVP_REPOSITORY` | explicit preferred | explicit `file` only for disposable single-instance demo | explicit durable store | explicit durable store |
 | `DATABASE_URL` | optional | prohibited while the candidate profile requires `file` | required for Prisma mode, secret-managed | required, secret-managed |
@@ -126,7 +127,7 @@ Gaps that block partner-beta:
 - MVP write and destructive reset routes have authentication but no CSRF defense beyond SameSite Lax, no per-user write rate limit and no reauthentication/confirmation contract;
 - workspace reset immediately replaces the user's workspace and has no export, grace period or recovery contract;
 - the bearer-token response expands exposure beyond an HTTP-only cookie, while logout does not revoke an already copied token;
-- no server-side admin role/endpoint contract exists;
+- the read-only admin overview uses an exact server-side email allowlist, but managed role lifecycle and cross-user/cohort administration are not implemented;
 - authentication errors reveal whether an invite is missing, claimed, or an account is registered; this is acceptable only for controlled invitation flows after abuse review;
 - auth file persistence can lose concurrent writes or expose a partial file after process interruption;
 - the MVP file repository treats any read or JSON parse failure as an empty store, so corruption can appear as data loss before a later write persists the empty state;

--- a/docs/superpowers/plans/2026-07-17-server-admin-authorization.md
+++ b/docs/superpowers/plans/2026-07-17-server-admin-authorization.md
@@ -1,0 +1,51 @@
+# Server Admin Authorization Implementation Plan
+
+> Issue #107. Execute with TDD and keep the server contract authoritative.
+
+**Goal:** Make the current internal MVP analytics surface depend on explicit server authorization while removing its destructive admin exposure.
+
+**Architecture:** A small allowlist parser and Express authorization middleware reuse `req.authUser`. A single read-only endpoint projects the current workspace to analytics/events/feedback. The UI fetches that projection and never treats its route guard as authority.
+
+**Dependencies:** Existing Express auth middleware, MVP repository, React query/store primitives, Vitest, Supertest. No new package.
+
+## Task 1: Lock the server boundary
+
+**Files:**
+- Modify: `api/__tests__/mvp.test.ts`
+- Modify: `api/app.ts`
+
+1. Add failing API tests for 401, 403, allowlisted 200, minimized response, and 404/405 for an admin reset route.
+2. Run the focused test and confirm the expected failures.
+3. Add the smallest normalized allowlist check and read-only endpoint.
+4. Run the focused API tests to green.
+
+## Task 2: Make the UI consume server authority
+
+**Files:**
+- Modify: `src/features/mvp/api/mvp.api.ts`
+- Modify: `src/features/mvp/pages/MvpSurfacePage.tsx`
+- Modify or add: relevant MVP UI tests
+
+1. Add a failing presentation test proving protected overview loading and no reset control.
+2. Add the typed API projection and load it only for `surface="admin"`.
+3. Render loading, denial, and overview states without reading privileged data directly from the general workspace store.
+4. Run focused UI tests to green.
+
+## Task 3: Align configuration and documentation
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` or test fixtures only if required
+- Modify: `README.md`
+- Modify: `docs/mvp/route-map.md`
+- Modify: `docs/mvp/canonical-mvp.md`
+- Modify: `docs/security/2026-07-16-operating-modes-threat-model.md`
+
+1. Document `LIFEOS_ADMIN_EMAILS` as an exact server allowlist and state that UI gates are secondary.
+2. Record that the endpoint is read-only/current-admin scoped and no admin reset exists.
+3. Keep partner beta unsupported until the remaining #108-#111 gates pass.
+
+## Task 4: Verify and integrate
+
+1. Run focused API/UI tests, full test suite, typecheck, lint, web/server builds, and canonical E2E.
+2. Run an independent security/code review and address material findings.
+3. Commit with Lore trailers, open a draft PR, inspect exact-head checks/comments, then mark ready and merge only when relevant gates are green.

--- a/docs/superpowers/specs/2026-07-17-server-admin-authorization-design.md
+++ b/docs/superpowers/specs/2026-07-17-server-admin-authorization-design.md
@@ -1,0 +1,30 @@
+# Server Admin Authorization Design
+
+Issue: #107
+Decision source: `docs/security/2026-07-16-operating-modes-threat-model.md`
+
+## Decision
+
+The canonical web runtime will reuse its existing authenticated user and add one server-side email allowlist, `LIFEOS_ADMIN_EMAILS`. Client flags, hostname checks, and user metadata remain presentation hints and never authorize an API request.
+
+The server exposes one read-only `GET /api/mvp/admin/overview` operation. It returns only the authenticated administrator's MVP analytics, event stream, and feedback. This matches the data the existing internal surface actually renders without inventing cross-user aggregation or repository-wide access.
+
+The admin surface loses its reset button. Workspace reset remains an authenticated user's self-service operation at `DELETE /api/mvp/workspace`; its confirmation, recovery, and CSRF redesign belong to #108. There is no admin reset endpoint.
+
+## Authorization contract
+
+- no session: `401` through the existing authentication middleware;
+- authenticated email absent from the normalized allowlist: `403`;
+- authenticated allowlisted email: `200` with only `analytics`, `events`, and `feedback`;
+- empty or malformed allowlist entries grant nothing;
+- invite code, hostname, development mode, Vite flags, and metadata do not participate in the server decision.
+
+The allowlist is an interim reversible policy for the current small internal surface. A database role system is deliberately deferred until roles must be managed dynamically.
+
+## Evidence
+
+API tests cover unauthenticated, ordinary-user, allowlisted-admin, feedback/event visibility, response minimization, and the absence of an admin reset route. UI tests only prove that the surface calls the protected endpoint and does not expose destructive reset.
+
+## Scope
+
+This change does not create cross-user analytics, mutable roles, an admin account-management API, a second token type, recoverable reset, partner-beta approval, or public-production support.

--- a/src/features/mvp/__tests__/MvpAdminSurface.test.tsx
+++ b/src/features/mvp/__tests__/MvpAdminSurface.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MvpSurfacePage } from '@/features/mvp/pages/MvpSurfacePage';
+import { createEmptyWorkspace } from '@/features/mvp/lib/state';
+import { useMvpStore } from '@/features/mvp/store/useMvpStore';
+
+const { getAdminOverview } = vi.hoisted(() => ({ getAdminOverview: vi.fn() }));
+
+vi.mock('@/features/mvp/api/mvp.api', () => ({
+  mvpApi: { getAdminOverview },
+}));
+
+describe('MVP admin surface', () => {
+  beforeEach(() => {
+    getAdminOverview.mockReset();
+  });
+
+  it('renders only the protected overview and does not hydrate or expose reset controls', async () => {
+    const workspace = createEmptyWorkspace();
+    const hydrateWorkspace = vi.fn();
+    useMvpStore.setState({ hydrateWorkspace });
+    getAdminOverview.mockResolvedValue({
+      analytics: { ...workspace.analytics, onboardingCompleted: true },
+      events: [{ id: 'event-1', type: 'user_feedback_submitted', createdAt: '2026-07-17T12:00:00.000Z' }],
+      feedback: [{ id: 'feedback-1', rating: 4, message: 'Useful signal.', createdAt: '2026-07-17T12:00:00.000Z' }],
+    });
+
+    render(
+      <MemoryRouter>
+        <MvpSurfacePage surface="admin" />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Useful signal.')).toBeInTheDocument();
+    expect(screen.getByText('user_feedback_submitted')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /reset mvp workspace/i })).not.toBeInTheDocument();
+    expect(hydrateWorkspace).not.toHaveBeenCalled();
+    expect(getAdminOverview).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/mvp/api/__tests__/mvp.api.test.ts
+++ b/src/features/mvp/api/__tests__/mvp.api.test.ts
@@ -38,4 +38,21 @@ describe('mvpApi desktop transport', () => {
     expect(getWorkspace).toHaveBeenCalledOnce();
     expect(global.window.api.legacy.request).not.toHaveBeenCalled();
   });
+
+  it('does not treat the local desktop bridge as administrative authority', async () => {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      writable: true,
+      value: {
+        electron: {},
+        api: {
+          mvp: { getWorkspace: vi.fn() },
+          legacy: { request: vi.fn() },
+        },
+      },
+    });
+
+    await expect(mvpApi.getAdminOverview()).rejects.toThrow('authenticated web server');
+    expect(global.window.api.legacy.request).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/mvp/api/mvp.api.ts
+++ b/src/features/mvp/api/mvp.api.ts
@@ -2,6 +2,7 @@ import { apiClient } from '@/shared/api/http';
 import { isDesktopApp } from '@/shared/lib/platform';
 import type {
   MvpDailyCheckIn,
+  MvpAdminOverview,
   MvpOnboardingDraft,
   MvpReflectionEntry,
   MvpReviewDraft,
@@ -41,6 +42,14 @@ function getDesktopMvpBridge() {
 }
 
 export const mvpApi = {
+  getAdminOverview: async () => {
+    if (getDesktopMvpBridge()) {
+      throw new Error('The administrative overview requires the authenticated web server.');
+    }
+
+    return unwrap(await apiClient.get<ApiResponse<MvpAdminOverview>>('/api/mvp/admin/overview'));
+  },
+
   getWorkspace: async () => {
     const desktopBridge = getDesktopMvpBridge();
     if (desktopBridge) {

--- a/src/features/mvp/pages/MvpSurfacePage.tsx
+++ b/src/features/mvp/pages/MvpSurfacePage.tsx
@@ -3,9 +3,10 @@ import { useEffect, useMemo, useState } from 'react';
 import { ArrowLeft, ArrowRight, Sparkles } from 'lucide-react';
 
 import { getMvpSurfaces } from '@/features/mvp/data';
+import { mvpApi } from '@/features/mvp/api/mvp.api';
 import { useMvpStore } from '@/features/mvp/store/useMvpStore';
 import { trackMvpSurfaceViewed } from '@/features/mvp/lib/telemetry';
-import type { MvpSurface } from '@/features/mvp/types';
+import type { MvpAdminOverview, MvpSurface } from '@/features/mvp/types';
 import { PageTitle } from '@/shared/ui/PageTitle';
 import { Card, CardHeader, CardTitle } from '@/shared/ui/Card';
 import { Button } from '@/shared/ui/Button';
@@ -447,11 +448,32 @@ function ReflectionSurface() {
 }
 
 function AdminSurface() {
-  const getAnalytics = useMvpStore((state) => state.getAnalytics);
-  const analytics = getAnalytics();
-  const events = useMvpStore((state) => state.events);
-  const feedback = useMvpStore((state) => state.feedback);
-  const resetWorkspace = useMvpStore((state) => state.resetWorkspace);
+  const [overview, setOverview] = useState<MvpAdminOverview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void mvpApi.getAdminOverview()
+      .then((result) => {
+        if (active) setOverview(result);
+      })
+      .catch((requestError: unknown) => {
+        if (active) setError(requestError instanceof Error ? requestError.message : 'Administrative access denied.');
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (error) {
+    return <Card className="p-5 text-sm text-rose-300">Administrative overview unavailable: {error}</Card>;
+  }
+
+  if (!overview) {
+    return <Card className="p-5 text-sm text-zinc-300">Loading protected administrative overview…</Card>;
+  }
+
+  const { analytics, events, feedback } = overview;
 
   return (
     <div className="space-y-4">
@@ -514,10 +536,6 @@ function AdminSurface() {
             <p className="text-sm text-zinc-400">No feedback entries yet.</p>
           )}
         </div>
-
-        <Button variant="destructive" onClick={() => resetWorkspace()}>
-          Reset MVP workspace
-        </Button>
       </Card>
     </div>
   );
@@ -537,8 +555,10 @@ export function MvpSurfacePage({ surface }: MvpSurfacePageProps) {
   const analytics = getAnalytics();
 
   useEffect(() => {
-    void hydrateWorkspace();
-  }, [hydrateWorkspace]);
+    if (surface !== 'admin') {
+      void hydrateWorkspace();
+    }
+  }, [hydrateWorkspace, surface]);
 
   useEffect(() => {
     trackMvpSurfaceViewed(surface);
@@ -549,7 +569,7 @@ export function MvpSurfacePage({ surface }: MvpSurfacePageProps) {
     'weekly-review': analytics.weeklyPlanConfirmed ? 'Confirmed' : analytics.eventCounts.weekly_plan_generated > 0 ? 'Generated' : 'Pending',
     today: analytics.totalActions > 0 ? `${analytics.completedActions}/${analytics.totalActions} done` : 'Pending',
     reflection: analytics.reflections > 0 ? `${analytics.reflections} saved` : 'Pending',
-    admin: `${analytics.feedbackEntries} feedback`,
+    admin: 'Protected',
   } satisfies Record<MvpSurface['slug'], string>;
 
   const content = {
@@ -562,10 +582,10 @@ export function MvpSurfacePage({ surface }: MvpSurfacePageProps) {
 
   return (
     <div className="space-y-8">
-      {isHydrating ? (
+      {surface !== 'admin' && isHydrating ? (
         <Card className="p-4 text-sm text-zinc-300">Syncing MVP workspace…</Card>
       ) : null}
-      {error ? (
+      {surface !== 'admin' && error ? (
         <Card className="p-4 text-sm text-rose-300">Workspace sync failed: {error}</Card>
       ) : null}
       <PageTitle

--- a/src/features/mvp/types.ts
+++ b/src/features/mvp/types.ts
@@ -125,3 +125,9 @@ export interface MvpWorkspaceSnapshot {
   events: MvpEvent[];
   analytics: MvpAnalyticsSnapshot;
 }
+
+export interface MvpAdminOverview {
+  analytics: MvpAnalyticsSnapshot;
+  events: MvpEvent[];
+  feedback: MvpFeedbackEntry[];
+}


### PR DESCRIPTION
Closes #107

## Outcome
- adds a fail-closed, exact-email server allowlist for the read-only admin overview
- returns only the authenticated administrator's analytics, events, and feedback
- makes client flags, localhost, invite metadata, and Electron presentation-only
- removes the destructive reset control from the admin surface
- aligns runtime configuration, canonical MVP docs, route map, and threat model

## Verification
- `npm test`: 79 passed files, 658 passed tests, 62 skipped
- `npm run typecheck`: passed
- `npm run lint`: 0 errors, 9 existing warnings
- `LIFEOS_OPERATING_MODE=local-dev npm run build`: passed
- `npm run build:server`: passed
- `docker compose config --quiet`: passed with representative controlled-demo values
- `git diff --check`: passed
- independent security review: no material findings

## Known boundary
The authenticated self-service workspace reset remains outside admin authority and is tracked by #108 for confirmation, CSRF, and recovery controls. TestSprite Pre-Check is an external no-tests-detected limitation and is not addressed here.