### PR TITLE
Harden the canonical HTTP trust boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ LIFEOS_SESSION_SECRET="$(openssl rand -hex 32)" npm run dev
 
 The admin route is only presentation until the server authorizes the signed-in identity. To authorize exact accounts, set a comma-separated allowlist such as `LIFEOS_ADMIN_EMAILS=operator@example.com`. An empty or malformed allowlist denies every account; client flags, localhost, invite metadata, and Electron do not grant administrator authority.
 
+The canonical HTTP server rejects JSON bodies above 32 KiB and validates every auth/profile/MVP write with strict bounded schemas. Cookie-authenticated unsafe requests require an exact allowed `Origin`; bearer tokens are explicit request authority. Logout revokes all existing web tokens for the account through a persisted session version. Express deliberately does not trust proxy headers in the supported direct single-process topology.
+
 The development scripts select `LIFEOS_OPERATING_MODE=local-dev`. Direct builds must select it explicitly:
 
 ```bash

--- a/api/__tests__/admin.test.ts
+++ b/api/__tests__/admin.test.ts
@@ -76,6 +76,6 @@ describe.sequential('server-authorized MVP admin overview', () => {
     const admin = request.agent(app())
     await register(admin, 'admin@example.test', 'ADMIN-INVITE')
 
-    expect((await admin.delete('/api/mvp/admin/overview')).status).toBe(404)
+    expect((await admin.delete('/api/mvp/admin/overview').set('Origin', 'http://localhost:5173')).status).toBe(404)
   })
 })

--- a/api/__tests__/auth.test.ts
+++ b/api/__tests__/auth.test.ts
@@ -67,6 +67,7 @@ describe('auth and invite access control', () => {
 
     expect(registration.status).toBe(201);
     expect(registration.body.user.email).toBe('partner@example.com');
+    const copiedBearer = registration.body.token as string;
 
     const verified = await invitedClient.get('/api/auth/verify');
     expect(verified.status).toBe(200);
@@ -75,11 +76,23 @@ describe('auth and invite access control', () => {
     const authedWorkspace = await invitedClient.get('/api/mvp/workspace');
     expect(authedWorkspace.status).toBe(200);
 
-    const logout = await invitedClient.post('/api/auth/logout').send({});
+    const invalidLogout = await invitedClient
+      .post('/api/auth/logout')
+      .set('Origin', 'http://localhost:5173')
+      .send({ unexpected: true });
+    expect(invalidLogout.status).toBe(400);
+    expect((await invitedClient.get('/api/auth/verify')).status).toBe(200);
+
+    const logout = await invitedClient.post('/api/auth/logout').set('Origin', 'http://localhost:5173').send({});
     expect(logout.status).toBe(200);
 
     const verifyAfterLogout = await invitedClient.get('/api/auth/verify');
     expect(verifyAfterLogout.status).toBe(401);
+
+    const copiedBearerAfterLogout = await request(app)
+      .get('/api/auth/verify')
+      .set('Authorization', `Bearer ${copiedBearer}`);
+    expect(copiedBearerAfterLogout.status).toBe(401);
 
     const login = await request(app).post('/api/auth/login').send({
       email: 'partner@example.com',
@@ -87,6 +100,45 @@ describe('auth and invite access control', () => {
     });
     expect(login.status).toBe(200);
     expect(login.body.token).toBeTruthy();
+  });
+
+  it('loads legacy users without a session version as version zero', async () => {
+    await fs.writeFile(authFile, JSON.stringify({
+      invites: [],
+      users: [{
+        id: 'usr_legacy',
+        email: 'legacy@example.test',
+        passwordHash: 'synthetic-hash',
+        fullName: 'Legacy User',
+        inviteCode: 'LEGACY',
+        theme: 'dark',
+        onboardingCompleted: false,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }],
+    }));
+
+    const user = await new FileBackedAuthRepository(authFile, []).findUserById('usr_legacy');
+    expect(user?.sessionVersion).toBe(0);
+  });
+
+  it('does not let a concurrent profile write roll back session revocation', async () => {
+    const repository = new FileBackedAuthRepository(authFile, [
+      { email: 'race@example.test', code: 'RACE-INVITE' },
+    ]);
+    const user = await repository.registerWithInvite({
+      email: 'race@example.test',
+      passwordHash: 'synthetic-hash',
+      fullName: 'Race User',
+      inviteCode: 'RACE-INVITE',
+    });
+
+    await Promise.all([
+      repository.revokeSessions(user.id),
+      repository.updateUser(user.id, { theme: 'light' }),
+    ]);
+
+    expect((await repository.findUserById(user.id))?.sessionVersion).toBe(1);
   });
 
   it('rejects a persisted fallback invite in controlled-demo', async () => {
@@ -129,7 +181,7 @@ describe('auth and invite access control', () => {
 
       expect(allowed.status).toBe(200);
       expect(allowed.headers['access-control-allow-origin']).toBe('https://demo.example.test');
-      expect(localhost.status).toBe(500);
+      expect(localhost.status).toBe(403);
       expect(localhost.headers['access-control-allow-origin']).toBeUndefined();
     } finally {
       if (previousMode === undefined) delete process.env.LIFEOS_OPERATING_MODE;

--- a/api/__tests__/httpBoundary.test.ts
+++ b/api/__tests__/httpBoundary.test.ts
@@ -1,0 +1,239 @@
+// @vitest-environment node
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import request from 'supertest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createApp } from '../app';
+import { FileBackedAuthRepository } from '../authRepository';
+import { FileBackedMvpRepository } from '../mvpRepository';
+import { onboardingRequestSchema } from '../requestSchemas';
+import { server } from '../../src/test/msw/server';
+
+describe.sequential('canonical HTTP request boundary', () => {
+  const origin = 'http://localhost:5173';
+  const mvpFile = path.join(os.tmpdir(), `lifeos-http-boundary-mvp-${process.pid}.json`);
+  const authFile = path.join(os.tmpdir(), `lifeos-http-boundary-auth-${process.pid}.json`);
+
+  beforeAll(() => {
+    server.close();
+  });
+
+  beforeEach(async () => {
+    await fs.rm(mvpFile, { force: true });
+    await fs.rm(authFile, { force: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(mvpFile, { force: true });
+    await fs.rm(authFile, { force: true });
+  });
+
+  afterAll(() => {
+    server.listen();
+  });
+
+  function buildApp(repository = new FileBackedMvpRepository(mvpFile)) {
+    return createApp(
+      repository,
+      new FileBackedAuthRepository(authFile, [{ email: 'boundary@example.test', code: 'BOUNDARY-INVITE' }]),
+    );
+  }
+
+  async function registeredSession() {
+    const app = buildApp();
+    const client = request.agent(app);
+    const registration = await client.post('/api/auth/register').set('Origin', origin).send({
+      email: 'boundary@example.test',
+      password: 'Password123!',
+      name: 'Boundary User',
+      inviteCode: 'BOUNDARY-INVITE',
+    });
+    expect(registration.status).toBe(201);
+    return { app, client, token: registration.body.token as string };
+  }
+
+  async function registeredClient() {
+    return (await registeredSession()).client;
+  }
+
+  it('rejects unknown and out-of-bound onboarding fields before persistence', async () => {
+    const client = await registeredClient();
+    const payload = {
+      displayName: 'Boundary User',
+      role: '',
+      lifeSeason: '',
+      planningPain: '',
+      successDefinition: '',
+      goals: Array.from({ length: 21 }, (_, index) => `Goal ${index}`),
+      commitments: [],
+      constraints: [],
+      injectedRole: 'admin',
+    };
+    expect(onboardingRequestSchema.safeParse(payload).success).toBe(false);
+    const invalid = await client.put('/api/mvp/onboarding').set('Origin', origin).send(payload);
+
+    expect(invalid.status).toBe(400);
+    const workspace = await client.get('/api/mvp/workspace');
+    expect(workspace.body.data.onboarding.completedAt).toBeNull();
+  });
+
+  it('rejects registration passwords that bcrypt would silently truncate', async () => {
+    const response = await request(buildApp()).post('/api/auth/register').send({
+      email: 'boundary@example.test',
+      password: 'x'.repeat(73),
+      name: 'Boundary User',
+      inviteCode: 'BOUNDARY-INVITE',
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects login suffixes beyond the bcrypt byte limit', async () => {
+    const app = buildApp();
+    const password = 'x'.repeat(72);
+    expect((await request(app).post('/api/auth/register').send({
+      email: 'boundary@example.test', password, name: 'Boundary User', inviteCode: 'BOUNDARY-INVITE',
+    })).status).toBe(201);
+
+    const login = await request(app).post('/api/auth/login').send({
+      email: 'boundary@example.test', password: `${password}x`,
+    });
+    expect(login.status).toBe(400);
+  });
+
+  it('rejects invalid calendar dates and numeric ranges', async () => {
+    const client = await registeredClient();
+    const invalidDate = await client.post('/api/mvp/daily-checkins').set('Origin', origin).send({
+      date: '2026-02-31',
+      energy: 0,
+      focus: 6,
+      blockers: '',
+      note: '',
+    });
+    const invalidFeedback = await client.post('/api/mvp/feedback').set('Origin', origin).send({
+      rating: 6,
+      message: 'Out of range',
+    });
+
+    expect(invalidDate.status).toBe(400);
+    expect(invalidFeedback.status).toBe(400);
+  });
+
+  it('rejects invalid shapes for every remaining canonical write', async () => {
+    const { app, client } = await registeredSession();
+    const requests = [
+      () => request(app).post('/api/auth/register').send({
+        email: 'other@example.test', password: 'Password123!', name: 'Other', inviteCode: 'OTHER', extra: true,
+      }),
+      () => request(app).post('/api/auth/login').send({ email: 'boundary@example.test', password: 'Password123!', extra: true }),
+      () => client.patch('/api/auth/profile').set('Origin', origin).send({ unexpected: true }),
+      () => client.post('/api/mvp/weekly-plans/generate').set('Origin', origin).send({
+        wins: [], unfinishedWork: [], constraints: [], focusArea: '', energyLevel: 6, notes: '',
+      }),
+      () => client.post('/api/mvp/weekly-plans/plan-id/confirm').set('Origin', origin).send({ unexpected: true }),
+      () => client.patch('/api/mvp/action-items/action-id').set('Origin', origin).send({}),
+      () => client.patch(`/api/mvp/action-items/${'x'.repeat(129)}`).set('Origin', origin).send({ status: 'done' }),
+      () => client.post('/api/mvp/reflections').set('Origin', origin).send({ period: 'monthly', body: '' }),
+    ];
+
+    for (const sendRequest of requests) {
+      expect((await sendRequest()).status).toBe(400);
+    }
+  });
+
+  it('returns 400 for malformed JSON and 413 above the 32 KiB contract', async () => {
+    const client = await registeredClient();
+    const malformed = await client
+      .post('/api/mvp/feedback')
+      .set('Origin', origin)
+      .set('Content-Type', 'application/json')
+      .send('{"rating":4');
+    const oversized = await client
+      .post('/api/mvp/feedback')
+      .set('Origin', origin)
+      .send({ rating: 4, message: 'x'.repeat(33 * 1024) });
+
+    expect(malformed.status).toBe(400);
+    expect(oversized.status).toBe(413);
+  });
+
+  it('requires an exact allowed Origin for cookie writes but not bearer writes', async () => {
+    const { app, client, token } = await registeredSession();
+    const payload = { rating: 4, message: 'Boundary signal' };
+
+    const missingOrigin = await client.post('/api/mvp/feedback').send(payload);
+    const crossOrigin = await client.post('/api/mvp/feedback').set('Origin', 'https://attacker.example').send(payload);
+    const exactOrigin = await client.post('/api/mvp/feedback').set('Origin', origin).send(payload);
+    const bearer = await request(app)
+      .post('/api/mvp/feedback')
+      .set('Authorization', `Bearer ${token}`)
+      .send(payload);
+
+    expect(missingOrigin.status).toBe(403);
+    expect(crossOrigin.status).toBe(403);
+    expect(exactOrigin.status).toBe(200);
+    expect(bearer.status).toBe(200);
+  });
+
+  it('does not touch the MVP repository before Origin and payload validation pass', async () => {
+    const repository = new FileBackedMvpRepository(mvpFile);
+    const ensureUser = vi.spyOn(repository, 'ensureUser');
+    const app = buildApp(repository);
+    const client = request.agent(app);
+    expect((await client.post('/api/auth/register').send({
+      email: 'boundary@example.test', password: 'Password123!', name: 'Boundary User', inviteCode: 'BOUNDARY-INVITE',
+    })).status).toBe(201);
+
+    expect((await client.post('/api/mvp/feedback').send({ rating: 4, message: 'No Origin' })).status).toBe(403);
+    expect((await client.post('/api/mvp/feedback').set('Origin', origin).send({ rating: 9, message: 'Invalid' })).status).toBe(400);
+    expect(ensureUser).not.toHaveBeenCalled();
+  });
+
+  it('throttles expensive plan generation by authenticated user', async () => {
+    const client = await registeredClient();
+    const payload = {
+      wins: [],
+      unfinishedWork: [],
+      constraints: [],
+      focusArea: 'Boundary hardening',
+      energyLevel: 3,
+      notes: '',
+    };
+
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      expect((await client.post('/api/mvp/weekly-plans/generate').set('Origin', origin).send(payload)).status).toBe(200);
+    }
+    expect((await client.post('/api/mvp/weekly-plans/generate').set('Origin', origin).send(payload)).status).toBe(429);
+  });
+
+  it('throttles ordinary writes by authenticated user', async () => {
+    const client = await registeredClient();
+    for (let attempt = 0; attempt < 120; attempt += 1) {
+      const response = await client
+        .post('/api/mvp/feedback')
+        .set('Origin', origin)
+        .send({ rating: 4, message: `Signal ${attempt}` });
+      expect(response.status).toBe(200);
+    }
+    expect((await client.post('/api/mvp/feedback').set('Origin', origin).send({ rating: 4, message: 'Throttled' })).status).toBe(429);
+  });
+
+  it('does not let forwarded headers bypass direct-peer auth throttling', async () => {
+    const app = buildApp();
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const response = await request(app)
+        .post('/api/auth/login')
+        .set('X-Forwarded-For', `203.0.113.${attempt + 1}`)
+        .send({ email: 'missing@example.test', password: 'WrongPassword' });
+      expect(response.status).toBe(401);
+    }
+    const throttled = await request(app)
+      .post('/api/auth/login')
+      .set('X-Forwarded-For', '198.51.100.200')
+      .send({ email: 'missing@example.test', password: 'WrongPassword' });
+    expect(throttled.status).toBe(429);
+  });
+});

--- a/api/__tests__/httpBoundary.test.ts
+++ b/api/__tests__/httpBoundary.test.ts
@@ -160,6 +160,55 @@ describe.sequential('canonical HTTP request boundary', () => {
     expect(oversized.status).toBe(413);
   });
 
+  it('rejects unparsed non-JSON bytes on routes with an empty-object contract', async () => {
+    const { client } = await registeredSession();
+
+    const logout = await client
+      .post('/api/auth/logout')
+      .set('Origin', origin)
+      .set('Content-Type', 'text/plain')
+      .send('unexpected');
+    const confirm = await client
+      .post('/api/mvp/weekly-plans/plan-id/confirm')
+      .set('Origin', origin)
+      .set('Content-Type', 'text/plain')
+      .send('unexpected');
+    const reset = await client
+      .delete('/api/mvp/workspace')
+      .set('Origin', origin)
+      .set('Content-Type', 'text/plain')
+      .send('unexpected');
+
+    expect(logout.status).toBe(400);
+    expect(confirm.status).toBe(400);
+    expect(reset.status).toBe(400);
+    expect((await client.get('/api/auth/verify')).status).toBe(200);
+  });
+
+  it('keeps the session valid and reports a server error when logout revocation cannot persist', async () => {
+    const authRepository = new FileBackedAuthRepository(
+      authFile,
+      [{ email: 'boundary@example.test', code: 'BOUNDARY-INVITE' }],
+    );
+    const app = createApp(new FileBackedMvpRepository(mvpFile), authRepository);
+    const client = request.agent(app);
+    const registration = await client.post('/api/auth/register').send({
+      email: 'boundary@example.test',
+      password: 'Password123!',
+      name: 'Boundary User',
+      inviteCode: 'BOUNDARY-INVITE',
+    });
+    vi.spyOn(authRepository, 'revokeSessions').mockRejectedValueOnce(new Error('disk unavailable'));
+
+    const logout = await client.post('/api/auth/logout').set('Origin', origin).send({});
+
+    expect(logout.status).toBe(500);
+    expect((await client.get('/api/auth/verify')).status).toBe(200);
+    expect((await request(app)
+      .get('/api/auth/verify')
+      .set('Authorization', `Bearer ${registration.body.token as string}`)).status).toBe(200);
+  });
+
   it('requires an exact allowed Origin for cookie writes but not bearer writes', async () => {
     const { app, client, token } = await registeredSession();
     const payload = { rating: 4, message: 'Boundary signal' };

--- a/api/__tests__/mvp.test.ts
+++ b/api/__tests__/mvp.test.ts
@@ -53,6 +53,7 @@ describe('MVP API contract', () => {
 
     const onboarding = await client
       .put('/api/mvp/onboarding')
+      .set('Origin', 'http://localhost:5173')
       .send({
         displayName: 'Pedro',
         role: 'Founding Engineer',
@@ -69,6 +70,7 @@ describe('MVP API contract', () => {
 
     const generated = await client
       .post('/api/mvp/weekly-plans/generate')
+      .set('Origin', 'http://localhost:5173')
       .send({
         wins: ['Shipped MVP shell'],
         unfinishedWork: ['Replace browser persistence'],
@@ -85,17 +87,19 @@ describe('MVP API contract', () => {
     const planId = generated.body.data.plan.id as string;
     const actionId = generated.body.data.plan.priorities[0].actions[0].id as string;
 
-    const confirmed = await client.post(`/api/mvp/weekly-plans/${planId}/confirm`).send();
+    const confirmed = await client.post(`/api/mvp/weekly-plans/${planId}/confirm`).set('Origin', 'http://localhost:5173').send();
     expect(confirmed.body.data.plan.confirmedAt).toBeTruthy();
 
     const updatedAction = await client
       .patch(`/api/mvp/action-items/${actionId}`)
+      .set('Origin', 'http://localhost:5173')
       .send({ status: 'done', note: 'Moved to complete during the test.' });
 
     expect(updatedAction.body.data.analytics.completedActions).toBe(1);
 
     const dailyCheckIn = await client
       .post('/api/mvp/daily-checkins')
+      .set('Origin', 'http://localhost:5173')
       .send({
         date: '2026-03-19',
         energy: 4,
@@ -108,11 +112,13 @@ describe('MVP API contract', () => {
 
     const reflection = await client
       .post('/api/mvp/reflections')
+      .set('Origin', 'http://localhost:5173')
       .send({ period: 'daily', body: 'The loop felt tighter with server state.' });
     expect(reflection.body.data.reflections).toHaveLength(1);
 
     const feedback = await client
       .post('/api/mvp/feedback')
+      .set('Origin', 'http://localhost:5173')
       .send({ rating: 5, message: 'Persistence now survives reloads.' });
     expect(feedback.body.data.feedback).toHaveLength(1);
 

--- a/api/app.ts
+++ b/api/app.ts
@@ -133,6 +133,16 @@ function parseRequest<T>(schema: z.ZodType<T>, value: unknown, res: express.Resp
   return parsed.data;
 }
 
+function parseEmptyRequest(req: express.Request, res: express.Response) {
+  const declaresBody = req.header('transfer-encoding') !== undefined
+    || Number(req.header('content-length') ?? '0') > 0;
+  if (req.body === undefined && declaresBody) {
+    fail(res, 'Validation failed', 400);
+    return null;
+  }
+  return parseRequest(emptyRequestSchema, req.body ?? {}, res);
+}
+
 export function createApp(
   repository: MvpRepository = createDefaultMvpRepository(),
   authRepository: AuthRepository = new FileBackedAuthRepository(),
@@ -272,16 +282,15 @@ export function createApp(
     }
   });
 
-  app.post('/api/auth/logout', requireAuthentication, requireCookieWriteOrigin, authenticatedWriteLimiter, async (req: AuthenticatedRequest, res) => {
+  app.post('/api/auth/logout', requireAuthentication, requireCookieWriteOrigin, authenticatedWriteLimiter, async (req: AuthenticatedRequest, res, next) => {
     try {
-      const body = parseRequest(emptyRequestSchema, req.body ?? {}, res);
+      const body = parseEmptyRequest(req, res);
       if (!body) return;
       await authRepository.revokeSessions(req.authUser!.id);
       clearSessionCookie(res);
       return ok(res, { message: 'Logged out' });
-    } catch {
-      clearSessionCookie(res);
-      return fail(res, 'Authentication required', 401);
+    } catch (error) {
+      return next(error);
     }
   });
 
@@ -353,7 +362,7 @@ export function createApp(
   app.post('/api/mvp/weekly-plans/:planId/confirm', async (req: AuthenticatedRequest, res, next) => {
     try {
       const planId = parseRequest(planIdSchema, req.params.planId, res);
-      const body = parseRequest(emptyRequestSchema, req.body ?? {}, res);
+      const body = parseEmptyRequest(req, res);
       if (!planId || !body) return;
       await repository.ensureUser(req.authUser!);
       ok(res, await repository.confirmPlan(req.authUser!.id, planId));
@@ -409,7 +418,7 @@ export function createApp(
 
   app.delete('/api/mvp/workspace', async (req: AuthenticatedRequest, res, next) => {
     try {
-      const body = parseRequest(emptyRequestSchema, req.body ?? {}, res);
+      const body = parseEmptyRequest(req, res);
       if (!body) return;
       await repository.ensureUser(req.authUser!);
       ok(res, await repository.resetWorkspace(req.authUser!.id));

--- a/api/app.ts
+++ b/api/app.ts
@@ -15,6 +15,20 @@ import { FileBackedAuthRepository, type StoredUser } from './authRepository';
 import { FileBackedMvpRepository } from './mvpRepository';
 import type { MvpRepository } from './mvpRepository.types';
 import { PrismaBackedMvpRepository } from './prismaMvpRepository';
+import {
+  actionItemIdSchema,
+  actionUpdateRequestSchema,
+  dailyCheckInRequestSchema,
+  emptyRequestSchema,
+  feedbackRequestSchema,
+  loginRequestSchema,
+  onboardingRequestSchema,
+  planIdSchema,
+  profileRequestSchema,
+  reflectionRequestSchema,
+  registerRequestSchema,
+  weeklyReviewRequestSchema,
+} from './requestSchemas';
 
 type AuthRepository = InstanceType<typeof FileBackedAuthRepository>;
 
@@ -32,10 +46,12 @@ const SESSION_TTL_SECONDS = 60 * 60 * 24 * 7;
 interface SessionClaims {
   sub: string;
   email: string;
+  sv: number;
 }
 
 interface AuthenticatedRequest extends express.Request {
   authUser?: StoredUser;
+  authSource?: 'bearer' | 'cookie';
 }
 
 function serializeUser(user: StoredUser) {
@@ -56,20 +72,30 @@ function serializeUser(user: StoredUser) {
 }
 
 function issueSessionToken(user: StoredUser) {
-  return jwt.sign({ email: user.email }, SESSION_SECRET, {
+  return jwt.sign({ email: user.email, sv: user.sessionVersion }, SESSION_SECRET, {
     subject: user.id,
     expiresIn: SESSION_TTL_SECONDS,
   });
 }
 
-function extractSessionToken(req: express.Request) {
+async function resolveAuthenticatedUser(req: express.Request, authRepository: AuthRepository) {
+  const session = extractSession(req);
+  if (!session) return null;
+
+  const claims = jwt.verify(session.token, SESSION_SECRET) as jwt.JwtPayload & SessionClaims;
+  const user = await authRepository.findUserById(claims.sub);
+  if (!user || claims.sv !== user.sessionVersion) return null;
+  return { user, source: session.source };
+}
+
+function extractSession(req: express.Request) {
   const authHeader = req.header('authorization');
   if (authHeader?.startsWith('Bearer ')) {
-    return authHeader.slice('Bearer '.length).trim();
+    return { token: authHeader.slice('Bearer '.length).trim(), source: 'bearer' as const };
   }
 
   const cookieToken = req.cookies?.[SESSION_COOKIE];
-  return typeof cookieToken === 'string' ? cookieToken : null;
+  return typeof cookieToken === 'string' ? { token: cookieToken, source: 'cookie' as const } : null;
 }
 
 function setSessionCookie(res: express.Response, token: string) {
@@ -98,12 +124,22 @@ function isConfiguredAdministrator(email: string) {
   return configuredEmails.includes(email.trim().toLowerCase());
 }
 
+function parseRequest<T>(schema: z.ZodType<T>, value: unknown, res: express.Response): T | null {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    fail(res, 'Validation failed', 400);
+    return null;
+  }
+  return parsed.data;
+}
+
 export function createApp(
   repository: MvpRepository = createDefaultMvpRepository(),
   authRepository: AuthRepository = new FileBackedAuthRepository(),
   options: CreateAppOptions = {}
 ) {
   const app = express();
+  app.set('trust proxy', false);
 
   const ALLOWED_ORIGINS = process.env.LIFEOS_OPERATING_MODE === 'controlled-demo'
     ? [process.env.ALLOWED_ORIGIN].filter(Boolean)
@@ -129,7 +165,7 @@ export function createApp(
     })
   );
   app.use(cookieParser());
-  app.use(express.json());
+  app.use(express.json({ limit: '32kb', strict: true }));
 
   app.get('/api/health', (_req, res) => {
     ok(res, { status: 'ok' });
@@ -141,27 +177,51 @@ export function createApp(
     message: { error: 'Too many attempts, please try again later' },
     standardHeaders: true,
     legacyHeaders: false,
+    validate: { xForwardedForHeader: false },
   });
 
-  const registerSchema = z.object({
-    email: z.string().email(),
-    password: z.string().min(8),
-    name: z.string().min(1),
-    inviteCode: z.string().min(1),
+  const authenticatedWriteLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 120,
+    keyGenerator: (req) => (req as AuthenticatedRequest).authUser!.id,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: (req) => ['GET', 'HEAD', 'OPTIONS'].includes(req.method),
   });
 
-  const loginSchema = z.object({
-    email: z.string().email(),
-    password: z.string().min(1),
+  const planGenerationLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000,
+    max: 20,
+    keyGenerator: (req) => (req as AuthenticatedRequest).authUser!.id,
+    standardHeaders: true,
+    legacyHeaders: false,
   });
+
+  const requireAuthentication = async (req: AuthenticatedRequest, res: express.Response, next: express.NextFunction) => {
+    try {
+      const session = await resolveAuthenticatedUser(req, authRepository);
+      if (!session) return fail(res, 'Authentication required', 401);
+      req.authUser = session.user;
+      req.authSource = session.source;
+      return next();
+    } catch {
+      return fail(res, 'Authentication required', 401);
+    }
+  };
+
+  const requireCookieWriteOrigin = (req: AuthenticatedRequest, res: express.Response, next: express.NextFunction) => {
+    if (['GET', 'HEAD', 'OPTIONS'].includes(req.method) || req.authSource === 'bearer') return next();
+    const origin = req.header('origin');
+    return origin && ALLOWED_ORIGINS.includes(origin)
+      ? next()
+      : fail(res, 'Origin verification failed', 403);
+  };
 
   app.post('/api/auth/register', authLimiter, async (req, res, next) => {
     try {
-      const parsed = registerSchema.safeParse(req.body);
-      if (!parsed.success) {
-        return fail(res, 'Validation failed');
-      }
-      const { email, password, name, inviteCode } = parsed.data;
+      const parsed = parseRequest(registerRequestSchema, req.body, res);
+      if (!parsed) return;
+      const { email, password, name, inviteCode } = parsed;
 
       const user = await authRepository.registerWithInvite({
         email,
@@ -182,11 +242,9 @@ export function createApp(
 
   app.post('/api/auth/login', authLimiter, async (req, res, next) => {
     try {
-      const parsed = loginSchema.safeParse(req.body);
-      if (!parsed.success) {
-        return fail(res, 'Validation failed');
-      }
-      const { email, password } = parsed.data;
+      const parsed = parseRequest(loginRequestSchema, req.body, res);
+      if (!parsed) return;
+      const { email, password } = parsed;
 
       const user = await authRepository.findUserByEmail(email);
       if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
@@ -203,39 +261,37 @@ export function createApp(
 
   app.get('/api/auth/verify', async (req, res) => {
     try {
-      const token = extractSessionToken(req);
-      if (!token) {
+      const session = await resolveAuthenticatedUser(req, authRepository);
+      if (!session) {
         return fail(res, 'Authentication required', 401);
       }
 
-      const claims = jwt.verify(token, SESSION_SECRET) as jwt.JwtPayload & SessionClaims;
-      const user = await authRepository.findUserById(claims.sub);
-      if (!user) {
-        return fail(res, 'Authentication required', 401);
-      }
-
-      return res.json(serializeUser(user));
+      return res.json(serializeUser(session.user));
     } catch {
       return fail(res, 'Authentication required', 401);
     }
   });
 
-  app.post('/api/auth/logout', (_req, res) => {
-    clearSessionCookie(res);
-    return ok(res, { message: 'Logged out' });
+  app.post('/api/auth/logout', requireAuthentication, requireCookieWriteOrigin, authenticatedWriteLimiter, async (req: AuthenticatedRequest, res) => {
+    try {
+      const body = parseRequest(emptyRequestSchema, req.body ?? {}, res);
+      if (!body) return;
+      await authRepository.revokeSessions(req.authUser!.id);
+      clearSessionCookie(res);
+      return ok(res, { message: 'Logged out' });
+    } catch {
+      clearSessionCookie(res);
+      return fail(res, 'Authentication required', 401);
+    }
   });
 
-  app.patch('/api/auth/profile', async (req, res) => {
+  app.patch('/api/auth/profile', requireAuthentication, requireCookieWriteOrigin, authenticatedWriteLimiter, async (req: AuthenticatedRequest, res) => {
     try {
-      const token = extractSessionToken(req);
-      if (!token) {
-        return fail(res, 'Authentication required', 401);
-      }
-
-      const claims = jwt.verify(token, SESSION_SECRET) as jwt.JwtPayload & SessionClaims;
-      const user = await authRepository.updateUser(claims.sub, {
-        fullName: typeof req.body?.name === 'string' ? req.body.name : undefined,
-        theme: req.body?.theme === 'light' || req.body?.theme === 'dark' ? req.body.theme : undefined,
+      const patch = parseRequest(profileRequestSchema, req.body, res);
+      if (!patch) return;
+      const user = await authRepository.updateUser(req.authUser!.id, {
+        fullName: patch.name,
+        theme: patch.theme,
       });
 
       return res.json({ user: serializeUser(user) });
@@ -244,29 +300,11 @@ export function createApp(
     }
   });
 
-  app.use('/api/mvp', async (req: AuthenticatedRequest, res, next) => {
-    try {
-      const token = extractSessionToken(req);
-      if (!token) {
-        return fail(res, 'Authentication required', 401);
-      }
-
-      const claims = jwt.verify(token, SESSION_SECRET) as jwt.JwtPayload & SessionClaims;
-      const user = await authRepository.findUserById(claims.sub);
-      if (!user) {
-        return fail(res, 'Authentication required', 401);
-      }
-
-      await repository.ensureUser(user);
-      req.authUser = user;
-      return next();
-    } catch {
-      return fail(res, 'Authentication required', 401);
-    }
-  });
+  app.use('/api/mvp', requireAuthentication, requireCookieWriteOrigin, authenticatedWriteLimiter);
 
   app.get('/api/mvp/workspace', async (req: AuthenticatedRequest, res, next) => {
     try {
+      await repository.ensureUser(req.authUser!);
       ok(res, await repository.getWorkspace(req.authUser!.id));
     } catch (error) {
       next(error);
@@ -279,6 +317,7 @@ export function createApp(
     }
 
     try {
+      await repository.ensureUser(req.authUser!);
       const workspace = await repository.getWorkspace(req.authUser!.id);
       const { analytics, events, feedback } = workspace;
       return ok(res, { analytics, events, feedback });
@@ -289,7 +328,10 @@ export function createApp(
 
   app.put('/api/mvp/onboarding', async (req: AuthenticatedRequest, res, next) => {
     try {
-      const snapshot = await repository.saveOnboarding(req.authUser!.id, req.body);
+      const input = parseRequest(onboardingRequestSchema, req.body, res);
+      if (!input) return;
+      await repository.ensureUser(req.authUser!);
+      const snapshot = await repository.saveOnboarding(req.authUser!.id, input);
       await authRepository.updateUser(req.authUser!.id, { onboardingCompleted: true });
       ok(res, snapshot);
     } catch (error) {
@@ -297,9 +339,12 @@ export function createApp(
     }
   });
 
-  app.post('/api/mvp/weekly-plans/generate', async (req: AuthenticatedRequest, res, next) => {
+  app.post('/api/mvp/weekly-plans/generate', planGenerationLimiter, async (req: AuthenticatedRequest, res, next) => {
     try {
-      ok(res, await repository.generatePlan(req.authUser!.id, req.body));
+      const input = parseRequest(weeklyReviewRequestSchema, req.body, res);
+      if (!input) return;
+      await repository.ensureUser(req.authUser!);
+      ok(res, await repository.generatePlan(req.authUser!.id, input));
     } catch (error) {
       next(error);
     }
@@ -307,7 +352,11 @@ export function createApp(
 
   app.post('/api/mvp/weekly-plans/:planId/confirm', async (req: AuthenticatedRequest, res, next) => {
     try {
-      ok(res, await repository.confirmPlan(req.authUser!.id, String(req.params.planId)));
+      const planId = parseRequest(planIdSchema, req.params.planId, res);
+      const body = parseRequest(emptyRequestSchema, req.body ?? {}, res);
+      if (!planId || !body) return;
+      await repository.ensureUser(req.authUser!);
+      ok(res, await repository.confirmPlan(req.authUser!.id, planId));
     } catch (error) {
       next(error);
     }
@@ -315,7 +364,11 @@ export function createApp(
 
   app.patch('/api/mvp/action-items/:actionItemId', async (req: AuthenticatedRequest, res, next) => {
     try {
-      ok(res, await repository.updateActionItem(req.authUser!.id, String(req.params.actionItemId), req.body));
+      const actionItemId = parseRequest(actionItemIdSchema, req.params.actionItemId, res);
+      const patch = parseRequest(actionUpdateRequestSchema, req.body, res);
+      if (!actionItemId || !patch) return;
+      await repository.ensureUser(req.authUser!);
+      ok(res, await repository.updateActionItem(req.authUser!.id, actionItemId, patch));
     } catch (error) {
       next(error);
     }
@@ -323,7 +376,10 @@ export function createApp(
 
   app.post('/api/mvp/daily-checkins', async (req: AuthenticatedRequest, res, next) => {
     try {
-      ok(res, await repository.saveDailyCheckIn(req.authUser!.id, req.body));
+      const input = parseRequest(dailyCheckInRequestSchema, req.body, res);
+      if (!input) return;
+      await repository.ensureUser(req.authUser!);
+      ok(res, await repository.saveDailyCheckIn(req.authUser!.id, input));
     } catch (error) {
       next(error);
     }
@@ -331,7 +387,10 @@ export function createApp(
 
   app.post('/api/mvp/reflections', async (req: AuthenticatedRequest, res, next) => {
     try {
-      ok(res, await repository.addReflection(req.authUser!.id, req.body));
+      const input = parseRequest(reflectionRequestSchema, req.body, res);
+      if (!input) return;
+      await repository.ensureUser(req.authUser!);
+      ok(res, await repository.addReflection(req.authUser!.id, input));
     } catch (error) {
       next(error);
     }
@@ -339,7 +398,10 @@ export function createApp(
 
   app.post('/api/mvp/feedback', async (req: AuthenticatedRequest, res, next) => {
     try {
-      ok(res, await repository.submitFeedback(req.authUser!.id, req.body));
+      const input = parseRequest(feedbackRequestSchema, req.body, res);
+      if (!input) return;
+      await repository.ensureUser(req.authUser!);
+      ok(res, await repository.submitFeedback(req.authUser!.id, input));
     } catch (error) {
       next(error);
     }
@@ -347,6 +409,9 @@ export function createApp(
 
   app.delete('/api/mvp/workspace', async (req: AuthenticatedRequest, res, next) => {
     try {
+      const body = parseRequest(emptyRequestSchema, req.body ?? {}, res);
+      if (!body) return;
+      await repository.ensureUser(req.authUser!);
       ok(res, await repository.resetWorkspace(req.authUser!.id));
     } catch (error) {
       next(error);
@@ -375,6 +440,16 @@ export function createApp(
   }
 
   app.use((error: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    const bodyError = error as { status?: number; type?: string };
+    if (bodyError.status === 413 || bodyError.type === 'entity.too.large') {
+      return fail(res, 'Payload too large', 413);
+    }
+    if (bodyError.status === 400 || bodyError.type === 'entity.parse.failed') {
+      return fail(res, 'Malformed JSON', 400);
+    }
+    if (error instanceof Error && error.message === 'Not allowed by CORS') {
+      return fail(res, 'Origin verification failed', 403);
+    }
     console.error('MVP API error:', error);
     const message = process.env.NODE_ENV === 'production'
       ? 'Internal server error'

--- a/api/authRepository.ts
+++ b/api/authRepository.ts
@@ -16,6 +16,7 @@ export interface StoredUser {
   inviteCode: string;
   theme: 'dark' | 'light';
   onboardingCompleted: boolean;
+  sessionVersion: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -40,10 +41,17 @@ function createId(prefix: string) {
 export class FileBackedAuthRepository {
   private filePath: string;
   private seedInvites: InviteSeed[];
+  private mutationQueue: Promise<void> = Promise.resolve();
 
   constructor(filePath = defaultFilePath(), seedInvites?: InviteSeed[]) {
     this.filePath = filePath;
     this.seedInvites = seedInvites ?? parseInviteSeeds(process.env.LIFEOS_INVITES);
+  }
+
+  private runMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.mutationQueue.then(operation, operation);
+    this.mutationQueue = result.then(() => undefined, () => undefined);
+    return result;
   }
 
   private async readState(): Promise<AuthState> {
@@ -108,7 +116,10 @@ export class FileBackedAuthRepository {
 
     return {
       invites: mergedInvites,
-      users: state.users,
+      users: state.users.map((user) => ({
+        ...user,
+        sessionVersion: Number.isInteger(user.sessionVersion) && user.sessionVersion >= 0 ? user.sessionVersion : 0,
+      })),
     };
   }
 
@@ -118,42 +129,45 @@ export class FileBackedAuthRepository {
     fullName: string;
     inviteCode: string;
   }) {
-    const state = await this.readState();
-    const email = normalizeEmail(input.email);
-    const inviteCode = input.inviteCode.trim();
+    return this.runMutation(async () => {
+      const state = await this.readState();
+      const email = normalizeEmail(input.email);
+      const inviteCode = input.inviteCode.trim();
 
-    const existingUser = state.users.find((user) => user.email === email);
-    if (existingUser) {
-      throw new Error('User already registered');
-    }
+      const existingUser = state.users.find((user) => user.email === email);
+      if (existingUser) {
+        throw new Error('User already registered');
+      }
 
-    const invite = state.invites.find((entry) => entry.email === email && entry.code === inviteCode);
-    if (!invite) {
-      throw new Error('Invite not found for this email');
-    }
+      const invite = state.invites.find((entry) => entry.email === email && entry.code === inviteCode);
+      if (!invite) {
+        throw new Error('Invite not found for this email');
+      }
 
-    if (invite.claimedAt) {
-      throw new Error('Invite already claimed');
-    }
+      if (invite.claimedAt) {
+        throw new Error('Invite already claimed');
+      }
 
-    const now = new Date().toISOString();
-    const user: StoredUser = {
-      id: createId('usr'),
-      email,
-      passwordHash: input.passwordHash,
-      fullName: input.fullName.trim(),
-      inviteCode,
-      theme: 'dark',
-      onboardingCompleted: false,
-      createdAt: now,
-      updatedAt: now,
-    };
+      const now = new Date().toISOString();
+      const user: StoredUser = {
+        id: createId('usr'),
+        email,
+        passwordHash: input.passwordHash,
+        fullName: input.fullName.trim(),
+        inviteCode,
+        theme: 'dark',
+        onboardingCompleted: false,
+        sessionVersion: 0,
+        createdAt: now,
+        updatedAt: now,
+      };
 
-    invite.claimedAt = now;
-    invite.claimedByUserId = user.id;
-    state.users.push(user);
-    await this.writeState(state);
-    return user;
+      invite.claimedAt = now;
+      invite.claimedByUserId = user.id;
+      state.users.push(user);
+      await this.writeState(state);
+      return user;
+    });
   }
 
   async findUserByEmail(email: string) {
@@ -167,24 +181,41 @@ export class FileBackedAuthRepository {
   }
 
   async updateUser(userId: string, patch: Partial<Pick<StoredUser, 'fullName' | 'theme' | 'onboardingCompleted'>>) {
-    const state = await this.readState();
-    const user = state.users.find((entry) => entry.id === userId);
-    if (!user) {
-      throw new Error('User not found');
-    }
+    return this.runMutation(async () => {
+      const state = await this.readState();
+      const user = state.users.find((entry) => entry.id === userId);
+      if (!user) {
+        throw new Error('User not found');
+      }
 
-    if (patch.fullName !== undefined) {
-      user.fullName = patch.fullName.trim();
-    }
-    if (patch.theme !== undefined) {
-      user.theme = patch.theme;
-    }
-    if (patch.onboardingCompleted !== undefined) {
-      user.onboardingCompleted = patch.onboardingCompleted;
-    }
-    user.updatedAt = new Date().toISOString();
+      if (patch.fullName !== undefined) {
+        user.fullName = patch.fullName.trim();
+      }
+      if (patch.theme !== undefined) {
+        user.theme = patch.theme;
+      }
+      if (patch.onboardingCompleted !== undefined) {
+        user.onboardingCompleted = patch.onboardingCompleted;
+      }
+      user.updatedAt = new Date().toISOString();
 
-    await this.writeState(state);
-    return user;
+      await this.writeState(state);
+      return user;
+    });
+  }
+
+  async revokeSessions(userId: string) {
+    return this.runMutation(async () => {
+      const state = await this.readState();
+      const user = state.users.find((entry) => entry.id === userId);
+      if (!user) {
+        throw new Error('User not found');
+      }
+
+      user.sessionVersion += 1;
+      user.updatedAt = new Date().toISOString();
+      await this.writeState(state);
+      return user;
+    });
   }
 }

--- a/api/requestSchemas.ts
+++ b/api/requestSchemas.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+
+const shortText = (max: number) => z.string().trim().max(max);
+const requiredText = (max: number) => shortText(max).min(1);
+const itemList = z.array(requiredText(300)).max(20);
+const rating = z.number().int().min(1).max(5);
+const bcryptPassword = (minimumLength: number) => z.string().min(minimumLength).max(128)
+  .refine((value) => Buffer.byteLength(value, 'utf8') <= 72, 'Password exceeds bcrypt limit');
+
+const calendarDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine((value) => {
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}, 'Invalid calendar date');
+
+export const registerRequestSchema = z.object({
+  email: z.string().trim().email().max(254),
+  password: bcryptPassword(8),
+  name: requiredText(100),
+  inviteCode: requiredText(128),
+}).strict();
+
+export const loginRequestSchema = z.object({
+  email: z.string().trim().email().max(254),
+  password: bcryptPassword(1),
+}).strict();
+
+export const profileRequestSchema = z.object({
+  name: requiredText(100).optional(),
+  theme: z.enum(['light', 'dark']).optional(),
+}).strict().refine((value) => value.name !== undefined || value.theme !== undefined, 'At least one field is required');
+
+export const onboardingRequestSchema = z.object({
+  displayName: requiredText(100),
+  role: shortText(200),
+  lifeSeason: shortText(200),
+  planningPain: shortText(2_000),
+  successDefinition: shortText(200),
+  goals: itemList,
+  commitments: itemList,
+  constraints: itemList,
+}).strict();
+
+export const weeklyReviewRequestSchema = z.object({
+  wins: itemList,
+  unfinishedWork: itemList,
+  constraints: itemList,
+  focusArea: shortText(200),
+  energyLevel: rating,
+  notes: shortText(2_000),
+}).strict();
+
+export const actionItemIdSchema = requiredText(128);
+export const planIdSchema = requiredText(128);
+
+export const actionUpdateRequestSchema = z.object({
+  status: z.enum(['todo', 'done', 'deferred']).optional(),
+  note: shortText(2_000).optional(),
+}).strict().refine((value) => value.status !== undefined || value.note !== undefined, 'At least one field is required');
+
+export const dailyCheckInRequestSchema = z.object({
+  date: calendarDate,
+  energy: rating,
+  focus: rating,
+  blockers: shortText(2_000),
+  note: shortText(2_000),
+}).strict();
+
+export const reflectionRequestSchema = z.object({
+  period: z.enum(['daily', 'weekly']),
+  body: requiredText(4_000),
+}).strict();
+
+export const feedbackRequestSchema = z.object({
+  rating,
+  message: requiredText(4_000),
+}).strict();
+
+export const emptyRequestSchema = z.object({}).strict();

--- a/docs/mvp/route-map.md
+++ b/docs/mvp/route-map.md
@@ -114,4 +114,10 @@ These routes exist in `src/config/routes/index.tsx`, but they are not canonical 
 
 - There is no implemented `POST /api/mvp/auth/invite/accept` endpoint. Invite acceptance currently happens through `POST /api/auth/register`.
 - Development mode, localhost, Vite flags, invite metadata, and UI visibility never authorize the backend admin endpoint.
+- All auth/profile/MVP writes use strict bounded Zod schemas; unknown fields and invalid values return `400`, malformed JSON returns `400`, and bodies above 32 KiB return `413`.
+- Cookie-authenticated unsafe methods require an exact configured `Origin`. Authorization bearer tokens are explicit authority and do not depend on browser CSRF protections.
+- Logout increments a persisted per-user session version, invalidating existing cookie and bearer tokens for that account.
+- Authentication is limited to 10 attempts per 15 minutes by direct peer, ordinary authenticated writes to 120 per 15 minutes per user, and plan generation to 20 per hour per user.
+- Express intentionally keeps `trust proxy=false`; forwarded client IP headers are not accepted in the supported direct deployment.
+- The current reset route is not yet the recoverable contract: #124 must replace it before parent #108 can close.
 - The route map should be treated as executable contract documentation, not as a proposal list. If a route is not implemented, do not document it here as current behavior.

--- a/docs/security/2026-07-16-operating-modes-threat-model.md
+++ b/docs/security/2026-07-16-operating-modes-threat-model.md
@@ -55,7 +55,7 @@ Trust boundaries:
 
 ### Canonical web identity
 
-For the canonical web runtime, the current identity source is `FileBackedAuthRepository`: registration claims an email-bound invite, bcrypt stores the password hash, and Express issues a seven-day JWT as an HTTP-only same-site cookie while also returning the token in the JSON response and accepting it as a bearer token. `/api/mvp/*` verifies the token and resolves the user before selecting a user-scoped workspace. No session-version, revocation store or token-rotation contract is observed; logout clears the cookie but cannot revoke a copied bearer token.
+For the canonical web runtime, the current identity source is `FileBackedAuthRepository`: registration claims an email-bound invite, bcrypt stores the password hash, and Express issues a seven-day JWT as an HTTP-only same-site cookie while also returning the token in the JSON response and accepting it as a bearer token. `/api/mvp/*` verifies the token, reloads the user, and compares a persisted session version before selecting a user-scoped workspace. Logout increments that version and therefore revokes every existing cookie and copied bearer token for the account. This global-logout policy is deliberate until a real per-device session requirement exists.
 
 The invite grants the right to create one account for the matching email. Once registered, the server session grants access to that user's MVP workspace. Invite metadata in the browser is neither authentication nor continuing authorization.
 
@@ -117,16 +117,13 @@ The shared validator in `shared/operatingMode.ts` is used by Vite and the Expres
 
 ## API, validation and abuse controls
 
-Observed controls: Helmet, credentialed CORS with an origin allowlist, Zod schemas on registration/login, bcrypt, signed expiring JWTs, and a 10-per-15-minute limiter on registration/login.
+Observed controls: Helmet, credentialed CORS with an origin allowlist, strict bounded Zod schemas on every canonical auth/profile/MVP write, a 32 KiB JSON limit, bcrypt, signed expiring versioned JWTs, exact-Origin enforcement for unsafe cookie-authenticated methods, a 10-per-15-minute direct-peer auth limiter, a 120-per-15-minute per-user write limiter, and a 20-per-hour per-user plan-generation limiter. Bearer authorization is explicit authority rather than ambient browser state. Express intentionally keeps `trust proxy=false`; forwarded client-IP headers do not influence these limits in the supported direct topology.
 
 Gaps that block partner-beta:
 
-- MVP request bodies are passed to repositories without equivalent boundary schemas or documented size limits;
-- profile patch accepts only selected primitive values but has no explicit body schema/length limit;
-- the general JSON parser uses its default limit rather than an application contract;
-- MVP write and destructive reset routes have authentication but no CSRF defense beyond SameSite Lax, no per-user write rate limit and no reauthentication/confirmation contract;
+- destructive reset still lacks password reauthentication, exact confirmation, a stricter destructive limiter, and a recoverable export contract; #124 owns this remaining parent requirement;
 - workspace reset immediately replaces the user's workspace and has no export, grace period or recovery contract;
-- the bearer-token response expands exposure beyond an HTTP-only cookie, while logout does not revoke an already copied token;
+- the bearer-token response expands exposure beyond an HTTP-only cookie, although persisted global logout now revokes copied tokens;
 - the read-only admin overview uses an exact server-side email allowlist, but managed role lifecycle and cross-user/cohort administration are not implemented;
 - authentication errors reveal whether an invite is missing, claimed, or an account is registered; this is acceptable only for controlled invitation flows after abuse review;
 - auth file persistence can lose concurrent writes or expose a partial file after process interruption;

--- a/docs/superpowers/plans/2026-07-17-http-boundary-session-hardening.md
+++ b/docs/superpowers/plans/2026-07-17-http-boundary-session-hardening.md
@@ -1,0 +1,89 @@
+# HTTP Boundary and Session Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every canonical Express write bounded and make logout revoke copied web sessions without trusting client-only or proxy-controlled state.
+
+**Architecture:** Put strict request schemas in one server module, resolve signed sessions through one helper, and apply the installed rate limiter at the route groups that own each cost. Persist one integer session version per file-backed user; no session table or refresh-token layer is introduced.
+
+**Tech Stack:** Express 5, Zod, express-rate-limit, jsonwebtoken, bcryptjs, Vitest, Supertest
+
+## Global Constraints
+
+- No new dependency.
+- JSON body limit is exactly 32 KiB.
+- `trust proxy` remains false.
+- Cookie-authenticated unsafe writes require an exact allowed Origin.
+- Logout revocation is persisted and invalidates copied bearer tokens.
+- Reset/recovery behavior remains owned by #124.
+
+---
+
+### Task 1: Strict request schemas and parser errors
+
+**Files:**
+- Create: `api/requestSchemas.ts`
+- Create: `api/__tests__/httpBoundary.test.ts`
+- Modify: `api/app.ts`
+
+**Interfaces:**
+- Produces strict exported schemas for every auth/profile/MVP write and `parseRequest(schema, value)` behavior in routes.
+- Produces 400 for invalid/malformed JSON and 413 above 32 KiB.
+
+- [ ] Write failing tests for unknown keys, invalid bounds, impossible dates, malformed JSON, and a 32 KiB overflow.
+- [ ] Run `npm test -- api/__tests__/httpBoundary.test.ts` and confirm failures are caused by the unbounded boundary.
+- [ ] Implement the schemas and parse them before every repository call.
+- [ ] Run the focused test and `npm run typecheck`; require green output.
+
+### Task 2: Persisted session revocation
+
+**Files:**
+- Modify: `api/authRepository.ts`
+- Modify: `api/app.ts`
+- Modify: `api/__tests__/auth.test.ts`
+- Modify: `electron/ipc/mvpHandler.ts`
+
+**Interfaces:**
+- `StoredUser.sessionVersion: number`
+- `FileBackedAuthRepository.revokeSessions(userId): Promise<StoredUser>`
+- JWT claim `sv: number`
+
+- [ ] Write a failing API test that copies the issued bearer, logs out, then receives 401 with that bearer.
+- [ ] Write a failing repository test showing a legacy user without `sessionVersion` loads as version zero.
+- [ ] Run the focused tests and confirm the missing revocation/version failures.
+- [ ] Add legacy normalization, emit `sv`, centralize authenticated-user resolution, and increment on logout.
+- [ ] Update the synthetic Electron `StoredUser` construction with version zero.
+- [ ] Re-run auth/API tests and typecheck.
+
+### Task 3: Cookie CSRF and cost-aware throttling
+
+**Files:**
+- Modify: `api/app.ts`
+- Modify: `api/__tests__/httpBoundary.test.ts`
+- Modify: `api/__tests__/auth.test.ts`
+- Modify: `api/__tests__/mvp.test.ts`
+
+**Interfaces:**
+- Session resolution returns token source `bearer|cookie`.
+- Ordinary write limiter: 120/15 minutes per authenticated user.
+- Plan generation limiter: 20/hour per authenticated user.
+
+- [ ] Write failing tests for cookie write without/mismatched Origin, allowed exact Origin, bearer write without Origin, auth throttling, expensive-write throttling, and spoofed `X-Forwarded-For` not bypassing direct-peer limiting.
+- [ ] Run the tests and confirm expected security failures.
+- [ ] Add the cookie-origin guard and installed rate limiters with user-ID keys after authentication.
+- [ ] Add exact allowed Origin headers to existing cookie-agent API fixtures.
+- [ ] Re-run focused tests and confirm 401/403/429 behavior.
+
+### Task 4: Documentation and complete verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/mvp/route-map.md`
+- Modify: `docs/security/2026-07-16-operating-modes-threat-model.md`
+
+- [ ] Document bounds, session revocation, CSRF token-source policy, limiter buckets, direct-peer proxy policy, and the #124 reset dependency.
+- [ ] Run focused tests, full `npm test`, `npm run typecheck`, `npm run lint`, local web build, server build, and `git diff --check`.
+- [ ] Request an independent security review; fix every material finding and rerun affected checks.
+- [ ] Commit with Lore trailers, push a draft PR closing #123, pass canonical GitHub gates, merge, and mark #123 validated.
+- [ ] Unblock #124 and continue the #108 parent without closing it.
+

--- a/docs/superpowers/plans/2026-07-17-http-boundary-session-hardening.md
+++ b/docs/superpowers/plans/2026-07-17-http-boundary-session-hardening.md
@@ -86,4 +86,3 @@
 - [ ] Request an independent security review; fix every material finding and rerun affected checks.
 - [ ] Commit with Lore trailers, push a draft PR closing #123, pass canonical GitHub gates, merge, and mark #123 validated.
 - [ ] Unblock #124 and continue the #108 parent without closing it.
-

--- a/docs/superpowers/specs/2026-07-17-http-boundary-session-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-17-http-boundary-session-hardening-design.md
@@ -14,8 +14,8 @@ The server continues to trust no proxy. This is deliberate for the supported dir
 
 All objects reject unknown keys. Path IDs are trimmed strings of 1 to 128 characters. Emails are valid and at most 254 characters. Passwords are bounded at 128 characters and are never trimmed.
 
-- registration: password 8–128; name 1–100; invite code 1–128;
-- login: non-empty password up to 128;
+- registration: password 8–128 characters and at most 72 UTF-8 bytes so bcrypt never truncates it; name 1–100; invite code 1–128;
+- login: non-empty password up to 128 characters and at most 72 UTF-8 bytes;
 - profile: optional name 1–100 and theme `light|dark`, with at least one field;
 - onboarding: display name 1–100; short context fields up to 200; planning pain up to 2,000; at most 20 non-empty items of up to 300 characters in each list;
 - weekly review: the same list bounds; focus area up to 200; integer energy 1–5; notes up to 2,000;
@@ -49,4 +49,3 @@ Rate-limit responses use 429. GET workspace/admin reads are not given a speculat
 ## Verification
 
 Focused API tests must prove bounds, unknown-key rejection, 413 handling, repository non-mutation, rate limits, cookie Origin denial, bearer behavior, copied-token invalidation after logout, legacy session-version compatibility, and untrusted forwarded headers. Full unit/integration tests, typecheck, lint, web/server builds, canonical browser E2E, and independent security review remain merge gates.
-

--- a/docs/superpowers/specs/2026-07-17-http-boundary-session-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-17-http-boundary-session-hardening-design.md
@@ -1,0 +1,52 @@
+# HTTP Boundary and Session Hardening Design
+
+Status: approved for autonomous execution
+Date: 2026-07-17
+Issues: #108, #123
+
+## Decision
+
+Harden the canonical Express server without adding dependencies or a second authentication system. Every request shape is parsed by strict Zod schemas before repository access. The global JSON parser accepts at most 32 KiB. Existing `express-rate-limit` protects authentication by source IP and authenticated writes by persisted user ID.
+
+The server continues to trust no proxy. This is deliberate for the supported direct single-process deployment: forwarded client headers never influence throttling. A future proxy topology must name exact trusted hops or networks before changing this policy.
+
+## Request contracts
+
+All objects reject unknown keys. Path IDs are trimmed strings of 1 to 128 characters. Emails are valid and at most 254 characters. Passwords are bounded at 128 characters and are never trimmed.
+
+- registration: password 8–128; name 1–100; invite code 1–128;
+- login: non-empty password up to 128;
+- profile: optional name 1–100 and theme `light|dark`, with at least one field;
+- onboarding: display name 1–100; short context fields up to 200; planning pain up to 2,000; at most 20 non-empty items of up to 300 characters in each list;
+- weekly review: the same list bounds; focus area up to 200; integer energy 1–5; notes up to 2,000;
+- action update: status `todo|done|deferred`, note up to 2,000, and at least one field;
+- daily check-in: a real `YYYY-MM-DD` calendar date, integer energy/focus 1–5, blockers/note up to 2,000;
+- reflection: period `daily|weekly`, body 1–4,000;
+- feedback: integer rating 1–5, message 1–4,000;
+- empty-body endpoints reject non-empty bodies.
+
+Validation failures return 400 and never call a repository. Payloads over 32 KiB return 413. Malformed JSON remains a 400 rather than leaking an internal error.
+
+## Session and CSRF policy
+
+Each persisted user has `sessionVersion`, defaulting legacy records to zero. JWTs carry that version. Verification, profile access, logout, and all MVP routes reload the user by signed `sub` and require an exact version match. Logout increments the persisted version before clearing the cookie, invalidating every copied bearer and cookie token for that account. This deliberately implements global logout; per-device sessions are out of scope until a real product requirement exists.
+
+Token extraction records whether authority came from `Authorization: Bearer` or the HTTP-only cookie. For unsafe authenticated methods, cookie authority requires an `Origin` exactly present in the server allowlist. Bearer authority does not require Origin because browsers do not attach that header ambiently. CORS remains a response/browser control and is not treated as authorization.
+
+## Throttling
+
+- register/login: 10 attempts per 15 minutes by direct peer IP;
+- authenticated ordinary writes: 120 per 15 minutes by user ID;
+- expensive plan generation: 20 per hour by user ID;
+- reset/recovery receives its own stricter limiter in #124.
+
+Rate-limit responses use 429. GET workspace/admin reads are not given a speculative limiter.
+
+## Scope and follow-up
+
+#123 does not implement reset recovery. #124 retains the parent acceptance for password reauthentication, exact confirmation, portable export, and file/Prisma recovery. #109 owns durable concurrency-safe persistence; #110 owns full account lifecycle/export. Electron payload validation is part of #111 unless it can reuse these schemas without changing the canonical web contract.
+
+## Verification
+
+Focused API tests must prove bounds, unknown-key rejection, 413 handling, repository non-mutation, rate limits, cookie Origin denial, bearer behavior, copied-token invalidation after logout, legacy session-version compatibility, and untrusted forwarded headers. Full unit/integration tests, typecheck, lint, web/server builds, canonical browser E2E, and independent security review remain merge gates.
+

--- a/electron/ipc/mvpHandler.ts
+++ b/electron/ipc/mvpHandler.ts
@@ -44,6 +44,7 @@ async function resolveDesktopUser(): Promise<StoredUser> {
     inviteCode: 'desktop-local',
     theme: 'dark',
     onboardingCompleted: false,
+    sessionVersion: 0,
     createdAt: new Date(0).toISOString(),
     updatedAt: new Date().toISOString(),
   };

--- a/tests/e2e/canonical.spec.ts
+++ b/tests/e2e/canonical.spec.ts
@@ -167,7 +167,10 @@ test('invited weekly loop persists and isolates each user', async ({ browser, pl
     expect(JSON.stringify(firstWorkspace)).toContain(`${marker}-reflection`)
     expect(JSON.stringify(firstWorkspace)).toContain(`${marker}-feedback`)
 
-    secondUserContext = await playwright.request.newContext({ baseURL: apiBase })
+    secondUserContext = await playwright.request.newContext({
+      baseURL: apiBase,
+      extraHTTPHeaders: { Origin: 'http://app.lifeos.test:3001' },
+    })
     const secondRegistration = await secondUserContext.post('/api/auth/register', {
       data: {
         email: 'canonical-b@example.test',

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -7,6 +7,7 @@
     "rootDir": ".",
     "outDir": "dist-server",
     "strict": false,
+    "strictNullChecks": true,
     "noImplicitAny": false,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- validate every canonical auth, profile, and MVP write with strict bounded schemas before persistence
- enforce a 32 KiB JSON limit, exact Origin for cookie-backed unsafe writes, and deliberate auth/per-user throttles
- persist a session version so logout revokes copied bearer and cookie tokens
- document the direct single-process no-trust-proxy policy and the reset-recovery handoff to #124

## Verification
- 671 tests passed across 80 files (62 skipped by the existing suite)
- focused auth/HTTP boundary: 17 passed
- typecheck: passed
- lint: 0 errors, 9 pre-existing warnings
- web build: passed
- server build: passed with strictNullChecks enabled
- git diff --check: passed
- independent security re-review: no material findings

## Deliberate limits
- no new dependencies
- global account logout, not speculative per-device session storage
- multiprocess coordination and crash-atomic auth persistence remain tracked by #109
- recoverable destructive reset remains tracked by #124; parent #108 must stay open until both children validate

Closes #123
Related: #108
Related: #124
Related: #109