### PR TITLE
Make destructive workspace reset recoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The admin route is only presentation until the server authorizes the signed-in i
 
 The canonical HTTP server rejects JSON bodies above 32 KiB and validates every auth/profile/MVP write with strict bounded schemas. Cookie-authenticated unsafe requests require an exact allowed `Origin`; bearer tokens are explicit request authority. Logout revokes all existing web tokens for the account through a persisted session version. Express deliberately does not trust proxy headers in the supported direct single-process topology.
 
+Canonical workspace reset is a two-step recovery operation, never a bodyless delete: password reauthentication plus the exact `RESET MY WORKSPACE` phrase prepares a versioned portable export and short-lived authorization; commit retains the recovery in the same repository mutation that clears data. `RESTORE MY WORKSPACE` restores a validated envelope, and the latest retained recovery remains available if the reset response is lost. This covers the canonical web workspace only; full account lifecycle is #110 and Electron recovery is #111.
+
 The development scripts select `LIFEOS_OPERATING_MODE=local-dev`. Direct builds must select it explicitly:
 
 ```bash

--- a/api/__tests__/httpBoundary.test.ts
+++ b/api/__tests__/httpBoundary.test.ts
@@ -181,7 +181,7 @@ describe.sequential('canonical HTTP request boundary', () => {
 
     expect(logout.status).toBe(400);
     expect(confirm.status).toBe(400);
-    expect(reset.status).toBe(400);
+    expect(reset.status).toBe(404);
     expect((await client.get('/api/auth/verify')).status).toBe(200);
   });
 

--- a/api/__tests__/prismaWorkspaceRecovery.test.ts
+++ b/api/__tests__/prismaWorkspaceRecovery.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createEmptyWorkspace, withComputedAnalytics } from '../../shared/mvp/state';
+import { PrismaBackedMvpRepository } from '../prismaMvpRepository';
+import { createWorkspaceExport } from '../workspaceRecovery';
+
+function transactionDouble() {
+  const empty = vi.fn().mockResolvedValue([]);
+  return {
+    userProfile: { findUnique: vi.fn().mockResolvedValue(null), create: vi.fn(), deleteMany: vi.fn() },
+    goal: { findMany: empty, createMany: vi.fn(), deleteMany: vi.fn() },
+    commitment: { findMany: empty, createMany: vi.fn(), deleteMany: vi.fn() },
+    weeklyReview: { findFirst: vi.fn().mockResolvedValue(null), create: vi.fn(), deleteMany: vi.fn() },
+    weeklyPlan: { findFirst: vi.fn().mockResolvedValue(null), create: vi.fn(), deleteMany: vi.fn() },
+    dailyCheckIn: { findMany: empty, createMany: vi.fn(), deleteMany: vi.fn() },
+    reflectionEntry: { findMany: empty, createMany: vi.fn(), deleteMany: vi.fn() },
+    feedbackEntry: { findMany: empty, createMany: vi.fn(), deleteMany: vi.fn() },
+    mvpEventLog: { findMany: empty, createMany: vi.fn(), deleteMany: vi.fn() },
+    mvpWorkspaceRecovery: {
+      create: vi.fn().mockResolvedValue({ id: 'recovery-1' }),
+      findMany: vi.fn().mockResolvedValue([]),
+      deleteMany: vi.fn(),
+    },
+  };
+}
+
+describe('Prisma workspace recovery', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('retains the prepared export before deleting workspace rows in one interactive transaction', async () => {
+    const tx = transactionDouble();
+    const db = { $transaction: vi.fn((callback) => callback(tx)) };
+    const repository = new PrismaBackedMvpRepository(db as never);
+    const prepared = createWorkspaceExport(createEmptyWorkspace(), '2026-07-17T12:00:00.000Z');
+
+    const result = await repository.resetWorkspace('user-1', prepared);
+
+    expect(db.$transaction).toHaveBeenCalledOnce();
+    expect(db.$transaction).toHaveBeenCalledWith(expect.any(Function), { isolationLevel: 'Serializable' });
+    expect(tx.mvpWorkspaceRecovery.create).toHaveBeenCalledWith({ data: expect.objectContaining({
+      userId: 'user-1', format: 'lifeos.mvp.workspace', version: 1,
+    }) });
+    expect(tx.mvpWorkspaceRecovery.create.mock.invocationCallOrder[0])
+      .toBeLessThan(tx.mvpEventLog.deleteMany.mock.invocationCallOrder[0]);
+    expect(tx.mvpWorkspaceRecovery.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { userId: 'user-1', id: { not: 'recovery-1' } }, skip: 4,
+    }));
+    expect(result).toEqual(expect.objectContaining({ recoveryId: 'recovery-1', export: prepared }));
+  });
+
+  it('does not retain or delete when the prepared export is stale', async () => {
+    const tx = transactionDouble();
+    const db = { $transaction: vi.fn((callback) => callback(tx)) };
+    const repository = new PrismaBackedMvpRepository(db as never);
+    const staleWorkspace = structuredClone(createEmptyWorkspace());
+    staleWorkspace.onboarding.displayName = 'changed';
+    const stale = createWorkspaceExport(staleWorkspace);
+
+    await expect(repository.resetWorkspace('user-1', stale)).rejects.toThrow('Workspace changed after export');
+    expect(tx.mvpWorkspaceRecovery.create).not.toHaveBeenCalled();
+    expect(tx.mvpEventLog.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('returns only the latest recovery scoped to the user', async () => {
+    const portableExport = createWorkspaceExport(createEmptyWorkspace(), '2026-07-17T12:00:00.000Z');
+    const findFirst = vi.fn().mockResolvedValue({ id: 'recovery-1', payload: portableExport });
+    const repository = new PrismaBackedMvpRepository({ mvpWorkspaceRecovery: { findFirst } } as never);
+
+    await expect(repository.getLatestRecovery('user-1')).resolves.toEqual({ id: 'recovery-1', export: portableExport });
+    expect(findFirst).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+    });
+  });
+
+  it('strictly replaces rows and preserves every represented relational id and timestamp', async () => {
+    const tx = transactionDouble();
+    tx.weeklyReview.create.mockResolvedValue({ id: 'review-1' });
+    const db = { $transaction: vi.fn((callback) => callback(tx)) };
+    const repository = new PrismaBackedMvpRepository(db as never);
+    const generatedAt = '2026-07-14T10:00:00.000Z';
+    const workspace = withComputedAnalytics({
+      ...createEmptyWorkspace(),
+      review: { id: 'review-1', wins: [], unfinishedWork: [], constraints: [], focusArea: '', energyLevel: 3, notes: '', generatedAt },
+      plan: {
+        id: 'plan-1', summary: 'Plan', weekLabel: 'Jul 14, 2026', generatedAt, confirmedAt: generatedAt,
+        priorities: [{
+          id: 'priority-1', title: 'Priority', rationale: '', successMetric: '',
+          actions: [{ id: 'action-1', title: 'Action', details: '', status: 'todo', note: '' }],
+        }],
+      },
+      reflections: [{ id: 'reflection-1', period: 'weekly', body: 'Body', createdAt: generatedAt }],
+      feedback: [{ id: 'feedback-1', rating: 5, message: 'Good', createdAt: generatedAt }],
+      events: [{ id: 'event-1', type: 'weekly_plan_confirmed', createdAt: generatedAt }],
+    });
+
+    await repository.restoreWorkspace('user-1', createWorkspaceExport(workspace));
+
+    expect(tx.mvpEventLog.deleteMany.mock.invocationCallOrder[0])
+      .toBeLessThan(tx.weeklyPlan.create.mock.invocationCallOrder[0]);
+    expect(tx.weeklyPlan.create).toHaveBeenCalledWith({ data: expect.objectContaining({
+      id: 'plan-1', weeklyReviewId: 'review-1',
+      priorities: { create: [expect.objectContaining({
+        id: 'priority-1',
+        actionItems: { create: [expect.objectContaining({ id: 'action-1', createdAt: new Date(generatedAt) })] },
+      })] },
+    }) });
+    expect(tx.reflectionEntry.createMany).toHaveBeenCalledWith({ data: [expect.objectContaining({ id: 'reflection-1', createdAt: new Date(generatedAt) })] });
+    expect(tx.feedbackEntry.createMany).toHaveBeenCalledWith({ data: [expect.objectContaining({ id: 'feedback-1', createdAt: new Date(generatedAt) })] });
+    expect(tx.mvpEventLog.createMany).toHaveBeenCalledWith({ data: [expect.objectContaining({ id: 'event-1', createdAt: new Date(generatedAt) })] });
+  });
+
+  it('does not start reset while an ordinary mutation for the same user is unsettled', async () => {
+    const tx = transactionDouble();
+    let finishFeedback!: (value: unknown[]) => void;
+    const pendingFeedback = new Promise<unknown[]>((resolve) => { finishFeedback = resolve; });
+    const db = {
+      ...tx,
+      feedbackEntry: { ...tx.feedbackEntry, create: vi.fn().mockResolvedValue({}) },
+      mvpEventLog: { ...tx.mvpEventLog, create: vi.fn().mockResolvedValue({}) },
+      $transaction: vi.fn((input: unknown) => {
+        if (Array.isArray(input)) return pendingFeedback;
+        return (input as (client: typeof tx) => unknown)(tx);
+      }),
+    };
+    const repository = new PrismaBackedMvpRepository(db as never);
+    const prepared = createWorkspaceExport(createEmptyWorkspace());
+
+    const feedback = repository.submitFeedback('user-1', { rating: 5, message: 'Keep this write' });
+    await vi.waitFor(() => expect(db.$transaction).toHaveBeenCalledTimes(1));
+    const reset = repository.resetWorkspace('user-1', prepared);
+    await Promise.resolve();
+    expect(db.$transaction).toHaveBeenCalledTimes(1);
+
+    finishFeedback([]);
+    await feedback;
+    await expect(reset).resolves.toEqual(expect.objectContaining({ recoveryId: 'recovery-1' }));
+    expect(db.$transaction).toHaveBeenCalledTimes(3);
+    expect(tx.mvpWorkspaceRecovery.create.mock.invocationCallOrder[0])
+      .toBeGreaterThan(db.$transaction.mock.invocationCallOrder[2]);
+  });
+});

--- a/api/__tests__/workspaceRecovery.test.ts
+++ b/api/__tests__/workspaceRecovery.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment node
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FileBackedMvpRepository } from '../mvpRepository';
+import { createEmptyWorkspace } from '../../shared/mvp/state';
+import { createWorkspaceExport, digestWorkspace, workspaceExportSchema } from '../workspaceRecovery';
+
+describe('file-backed workspace recovery invariants', () => {
+  const dataFile = path.join(os.tmpdir(), `lifeos-workspace-recovery-${process.pid}.json`);
+  const userId = 'usr_recovery';
+
+  beforeEach(async () => {
+    await fs.rm(dataFile, { force: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(dataFile, { force: true });
+  });
+
+  async function populatedRepository() {
+    const repository = new FileBackedMvpRepository(dataFile);
+    await repository.saveOnboarding(userId, {
+      displayName: 'Recovery User',
+      role: 'Maintainer',
+      lifeSeason: 'Launch',
+      planningPain: 'Unsafe reset',
+      successDefinition: 'Recoverable data',
+      goals: ['Ship recovery'],
+      commitments: ['Verify backups'],
+      constraints: ['No data loss'],
+    });
+    await repository.addReflection(userId, { period: 'daily', body: 'Keep this reflection.' });
+    return repository;
+  }
+
+  it('retains a portable export in the same mutation as reset and restores it exactly', async () => {
+    const repository = await populatedRepository();
+    const prepared = await repository.exportWorkspace(userId);
+
+    const reset = await repository.resetWorkspace(userId, prepared);
+
+    expect(reset.workspace.onboarding.completedAt).toBeNull();
+    expect(reset.export).toEqual(prepared);
+    const retained = await repository.getLatestRecovery(userId);
+    expect(retained).toEqual({ id: reset.recoveryId, export: prepared });
+
+    const restored = await repository.restoreWorkspace(userId, retained!.export);
+    expect(restored).toEqual(prepared.workspace);
+  });
+
+  it('recomputes untrusted analytics before retaining the recovery export', async () => {
+    const repository = await populatedRepository();
+    const prepared = await repository.exportWorkspace(userId);
+    prepared.workspace.analytics.feedbackEntries = 999;
+
+    const reset = await repository.resetWorkspace(userId, prepared);
+
+    expect(reset.export.workspace.analytics.feedbackEntries).toBe(0);
+    expect((await repository.getLatestRecovery(userId))!.export.workspace.analytics.feedbackEntries).toBe(0);
+  });
+
+  it('rejects a stale prepared digest without clearing or retaining a false recovery', async () => {
+    const repository = await populatedRepository();
+    const before = await repository.getWorkspace(userId);
+
+    const stale = await repository.exportWorkspace(userId);
+    stale.workspace = { ...stale.workspace, reflections: [] };
+    expect(digestWorkspace(stale.workspace)).not.toBe(digestWorkspace(before));
+    await expect(repository.resetWorkspace(userId, stale))
+      .rejects.toThrow('Workspace changed after export');
+
+    expect(await repository.getWorkspace(userId)).toEqual(before);
+    expect(await repository.getLatestRecovery(userId)).toBeNull();
+  });
+
+  it('preserves the original workspace when the combined recovery/reset write fails', async () => {
+    const repository = await populatedRepository();
+    const before = await repository.getWorkspace(userId);
+    const prepared = await repository.exportWorkspace(userId);
+    const writeFailure = vi.spyOn(fs, 'writeFile').mockRejectedValueOnce(new Error('disk unavailable'));
+
+    await expect(repository.resetWorkspace(userId, prepared)).rejects.toThrow('disk unavailable');
+    writeFailure.mockRestore();
+
+    expect(await repository.getWorkspace(userId)).toEqual(before);
+    expect(await repository.getLatestRecovery(userId)).toBeNull();
+  });
+
+  it('rejects an unsupported portable version before replacing current data', async () => {
+    const repository = await populatedRepository();
+    const before = await repository.getWorkspace(userId);
+    const portableExport = await repository.exportWorkspace(userId);
+
+    await expect(repository.restoreWorkspace(userId, { ...portableExport, version: 2 } as never))
+      .rejects.toThrow();
+
+    expect(await repository.getWorkspace(userId)).toEqual(before);
+  });
+
+  it.each([
+    ['review id without generatedAt', (workspace: ReturnType<typeof createEmptyWorkspace>) => {
+      workspace.review.id = 'review-orphan';
+    }],
+    ['review generatedAt without id', (workspace: ReturnType<typeof createEmptyWorkspace>) => {
+      workspace.review.generatedAt = '2026-07-17T00:00:00.000Z';
+    }],
+    ['review content without a persisted review', (workspace: ReturnType<typeof createEmptyWorkspace>) => {
+      workspace.review.wins = ['Must not be silently dropped'];
+    }],
+    ['plan id without generatedAt', (workspace: ReturnType<typeof createEmptyWorkspace>) => {
+      workspace.plan.id = 'plan-orphan';
+    }],
+    ['plan priorities without a plan', (workspace: ReturnType<typeof createEmptyWorkspace>) => {
+      workspace.plan.priorities = [{ id: 'priority-orphan', title: 'Orphan', rationale: '', successMetric: '', actions: [] }];
+    }],
+    ['plan metadata without a persisted plan', (workspace: ReturnType<typeof createEmptyWorkspace>) => {
+      workspace.plan.summary = 'Must not be silently dropped';
+    }],
+    ['plan confirmation without a plan', (workspace: ReturnType<typeof createEmptyWorkspace>) => {
+      workspace.plan.confirmedAt = '2026-07-17T00:00:00.000Z';
+    }],
+  ])('rejects an inconsistent portable envelope: %s', (_label, mutate) => {
+    const envelope = createWorkspaceExport(createEmptyWorkspace());
+    mutate(envelope.workspace);
+    expect(workspaceExportSchema.safeParse(envelope).success).toBe(false);
+  });
+
+  it('serializes reset and restore with ordinary mutations for the same user', async () => {
+    const repository = await populatedRepository();
+    const prepared = await repository.exportWorkspace(userId);
+
+    const update = repository.addReflection(userId, { period: 'daily', body: 'Committed before reset.' });
+    const reset = repository.resetWorkspace(userId, prepared);
+    await update;
+    await expect(reset).rejects.toThrow('Workspace changed after export');
+    expect((await repository.getWorkspace(userId)).reflections.map(({ body }) => body))
+      .toContain('Committed before reset.');
+
+    const restore = repository.restoreWorkspace(userId, prepared);
+    const postRestoreUpdate = repository.addReflection(userId, { period: 'daily', body: 'Committed after restore.' });
+    await restore;
+    await postRestoreUpdate;
+    expect((await repository.getWorkspace(userId)).reflections.map(({ body }) => body))
+      .toEqual(expect.arrayContaining(['Keep this reflection.', 'Committed after restore.']));
+  });
+});

--- a/api/__tests__/workspaceRecoveryHttp.test.ts
+++ b/api/__tests__/workspaceRecoveryHttp.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment node
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import request from 'supertest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { createApp } from '../app';
+import { FileBackedAuthRepository } from '../authRepository';
+import { FileBackedMvpRepository } from '../mvpRepository';
+import { server } from '../../src/test/msw/server';
+
+describe.sequential('recoverable workspace HTTP contract', () => {
+  const origin = 'http://localhost:5173';
+  const password = 'Password123!';
+  const mvpFile = path.join(os.tmpdir(), `lifeos-recovery-http-mvp-${process.pid}.json`);
+  const authFile = path.join(os.tmpdir(), `lifeos-recovery-http-auth-${process.pid}.json`);
+
+  beforeAll(() => server.close());
+  afterAll(() => server.listen());
+  beforeEach(async () => Promise.all([fs.rm(mvpFile, { force: true }), fs.rm(authFile, { force: true })]));
+  afterEach(async () => Promise.all([fs.rm(mvpFile, { force: true }), fs.rm(authFile, { force: true })]));
+
+  async function session() {
+    const app = createApp(
+      new FileBackedMvpRepository(mvpFile),
+      new FileBackedAuthRepository(authFile, [{ email: 'recovery@example.test', code: 'RECOVERY-INVITE' }]),
+    );
+    const client = request.agent(app);
+    expect((await client.post('/api/auth/register').send({
+      email: 'recovery@example.test', password, name: 'Recovery User', inviteCode: 'RECOVERY-INVITE',
+    })).status).toBe(201);
+    expect((await client.put('/api/mvp/onboarding').set('Origin', origin).send({
+      displayName: 'Recovery User', role: 'Maintainer', lifeSeason: 'Launch', planningPain: 'Data loss',
+      successDefinition: 'Restored', goals: ['Recover'], commitments: [], constraints: [],
+    })).status).toBe(200);
+    return { app, client };
+  }
+
+  async function loggedInSession() {
+    const app = createApp(new FileBackedMvpRepository(mvpFile), new FileBackedAuthRepository(authFile));
+    const client = request.agent(app);
+    expect((await client.post('/api/auth/login').send({
+      email: 'recovery@example.test', password,
+    })).status).toBe(200);
+    return { app, client };
+  }
+
+  it('requires password and exact phrase, removes bodyless DELETE, and rejects stale reset tokens', async () => {
+    const { client } = await session();
+    expect((await client.delete('/api/mvp/workspace').set('Origin', origin).send({})).status).toBe(404);
+    expect((await client.post('/api/mvp/workspace/reset/export').send({
+      password, confirmation: 'RESET MY WORKSPACE',
+    })).status).toBe(403);
+    expect((await client.post('/api/mvp/workspace/recovery').send({
+      password, confirmation: 'RESTORE MY WORKSPACE', export: await new FileBackedMvpRepository(mvpFile).exportWorkspace('missing-user'),
+    })).status).toBe(403);
+    const { client: invalidClient } = await loggedInSession();
+    expect((await invalidClient.post('/api/mvp/workspace/reset/export').set('Origin', origin).send({
+      password: 'WrongPassword', confirmation: 'RESET MY WORKSPACE',
+    })).status).toBe(401);
+    expect((await invalidClient.post('/api/mvp/workspace/reset/export').set('Origin', origin).send({
+      password, confirmation: 'reset my workspace',
+    })).status).toBe(400);
+
+    const prepared = await client.post('/api/mvp/workspace/reset/export').set('Origin', origin).send({
+      password, confirmation: 'RESET MY WORKSPACE',
+    });
+    expect(prepared.status).toBe(200);
+
+    const alteredEnvelope = structuredClone(prepared.body.data.export);
+    alteredEnvelope.exportedAt = '2026-07-17T00:00:00.000Z';
+    expect((await client.post('/api/mvp/workspace/reset').set('Origin', origin).send({
+      password, confirmation: 'RESET MY WORKSPACE', resetToken: prepared.body.data.resetToken,
+      export: alteredEnvelope,
+    })).status).toBe(401);
+
+    expect((await client.post('/api/mvp/reflections').set('Origin', origin).send({
+      period: 'daily', body: 'Changed after export',
+    })).status).toBe(200);
+    const staleReset = await client.post('/api/mvp/workspace/reset').set('Origin', origin).send({
+      password, confirmation: 'RESET MY WORKSPACE', resetToken: prepared.body.data.resetToken,
+      export: prepared.body.data.export,
+    });
+    expect(staleReset.status).toBe(409);
+    expect((await client.get('/api/mvp/workspace')).body.data.reflections).toHaveLength(1);
+  });
+
+  it('retains recovery after reset response loss and restores a portable envelope above 32 KiB', async () => {
+    const { client } = await session();
+    const prepared = await client.post('/api/mvp/workspace/reset/export').set('Origin', origin).send({
+      password, confirmation: 'RESET MY WORKSPACE',
+    });
+    const reset = await client.post('/api/mvp/workspace/reset').set('Origin', origin).send({
+      password, confirmation: 'RESET MY WORKSPACE', resetToken: prepared.body.data.resetToken,
+      export: prepared.body.data.export,
+    });
+    expect(reset.status).toBe(200);
+    expect(reset.body.data.workspace.onboarding.completedAt).toBeNull();
+
+    const retained = await client.get('/api/mvp/workspace/recovery/latest');
+    expect(retained.status).toBe(200);
+    expect(retained.body.data.export).toEqual(prepared.body.data.export);
+
+    const portableExport = retained.body.data.export;
+    portableExport.workspace.reflections = Array.from({ length: 20 }, (_, index) => ({
+      id: `reflection-${index}`,
+      period: 'daily',
+      body: `recovery-${index}-${'x'.repeat(2_000)}`,
+      createdAt: '2026-07-17T00:00:00.000Z',
+    }));
+    const recovery = await client.post('/api/mvp/workspace/recovery').set('Origin', origin).send({
+      password, confirmation: 'RESTORE MY WORKSPACE', export: portableExport,
+    });
+    expect(recovery.status).toBe(200);
+    expect(recovery.body.data.reflections).toHaveLength(20);
+  });
+
+  it('counts failed attempts in separate deterministic reset and recovery rate limits', async () => {
+    const { client } = await session();
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      expect((await client.post('/api/mvp/workspace/reset/export').set('Origin', origin).send({
+        password: 'WrongPassword', confirmation: 'RESET MY WORKSPACE',
+      })).status).toBe(401);
+    }
+    expect((await client.post('/api/mvp/workspace/reset/export').set('Origin', origin).send({
+      password, confirmation: 'RESET MY WORKSPACE',
+    })).status).toBe(429);
+
+    const prepared = await new FileBackedMvpRepository(mvpFile).exportWorkspace('missing-user');
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      expect((await client.post('/api/mvp/workspace/recovery').set('Origin', origin).send({
+        password: 'WrongPassword', confirmation: 'RESTORE MY WORKSPACE', export: prepared,
+      })).status).toBe(401);
+    }
+    expect((await client.post('/api/mvp/workspace/recovery').set('Origin', origin).send({
+      password, confirmation: 'RESTORE MY WORKSPACE', export: prepared,
+    })).status).toBe(429);
+  });
+});

--- a/api/app.ts
+++ b/api/app.ts
@@ -27,8 +27,14 @@ import {
   profileRequestSchema,
   reflectionRequestSchema,
   registerRequestSchema,
+  resetCommitRequestSchema,
+  resetPreparationRequestSchema,
   weeklyReviewRequestSchema,
+  workspaceRecoveryRequestSchema,
 } from './requestSchemas';
+import {
+  digestWorkspaceExport,
+} from './workspaceRecovery';
 
 type AuthRepository = InstanceType<typeof FileBackedAuthRepository>;
 
@@ -47,6 +53,12 @@ interface SessionClaims {
   sub: string;
   email: string;
   sv: number;
+}
+
+interface WorkspaceResetClaims {
+  sub: string;
+  kind: 'workspace-reset';
+  digest: string;
 }
 
 interface AuthenticatedRequest extends express.Request {
@@ -175,7 +187,13 @@ export function createApp(
     })
   );
   app.use(cookieParser());
-  app.use(express.json({ limit: '32kb', strict: true }));
+  const ordinaryJsonParser = express.json({ limit: '32kb', strict: true });
+  const portableWorkspaceJsonParser = express.json({ limit: '10mb', strict: true });
+  app.use((req, res, next) => {
+    const portableWorkspacePath = req.path === '/api/mvp/workspace/reset'
+      || req.path === '/api/mvp/workspace/recovery';
+    return portableWorkspacePath ? next() : ordinaryJsonParser(req, res, next);
+  });
 
   app.get('/api/health', (_req, res) => {
     ok(res, { status: 'ok' });
@@ -202,6 +220,22 @@ export function createApp(
   const planGenerationLimiter = rateLimit({
     windowMs: 60 * 60 * 1000,
     max: 20,
+    keyGenerator: (req) => (req as AuthenticatedRequest).authUser!.id,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+
+  const destructiveResetLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000,
+    max: 3,
+    keyGenerator: (req) => (req as AuthenticatedRequest).authUser!.id,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+
+  const recoveryLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000,
+    max: 3,
     keyGenerator: (req) => (req as AuthenticatedRequest).authUser!.id,
     standardHeaders: true,
     legacyHeaders: false,
@@ -416,14 +450,73 @@ export function createApp(
     }
   });
 
-  app.delete('/api/mvp/workspace', async (req: AuthenticatedRequest, res, next) => {
+  app.post('/api/mvp/workspace/reset/export', destructiveResetLimiter, async (req: AuthenticatedRequest, res, next) => {
     try {
-      const body = parseEmptyRequest(req, res);
-      if (!body) return;
+      const input = parseRequest(resetPreparationRequestSchema, req.body, res);
+      if (!input) return;
+      if (!(await bcrypt.compare(input.password, req.authUser!.passwordHash))) {
+        return fail(res, 'Password reauthentication failed', 401);
+      }
       await repository.ensureUser(req.authUser!);
-      ok(res, await repository.resetWorkspace(req.authUser!.id));
+      const portableExport = await repository.exportWorkspace(req.authUser!.id);
+      const resetToken = jwt.sign({
+        kind: 'workspace-reset',
+        digest: digestWorkspaceExport(portableExport),
+      }, SESSION_SECRET, { subject: req.authUser!.id, expiresIn: 10 * 60 });
+      return ok(res, { export: portableExport, resetToken });
     } catch (error) {
-      next(error);
+      return next(error);
+    }
+  });
+
+  app.post('/api/mvp/workspace/reset', destructiveResetLimiter, portableWorkspaceJsonParser, async (req: AuthenticatedRequest, res, next) => {
+    try {
+      const input = parseRequest(resetCommitRequestSchema, req.body, res);
+      if (!input) return;
+      if (!(await bcrypt.compare(input.password, req.authUser!.passwordHash))) {
+        return fail(res, 'Password reauthentication failed', 401);
+      }
+      const claims = jwt.verify(input.resetToken, SESSION_SECRET) as jwt.JwtPayload & WorkspaceResetClaims;
+      if (claims.sub !== req.authUser!.id || claims.kind !== 'workspace-reset') {
+        return fail(res, 'Invalid reset authorization', 401);
+      }
+      if (claims.digest !== digestWorkspaceExport(input.export)) {
+        return fail(res, 'Invalid reset authorization', 401);
+      }
+      await repository.ensureUser(req.authUser!);
+      return ok(res, await repository.resetWorkspace(req.authUser!.id, input.export));
+    } catch (error) {
+      if (error instanceof Error && error.message === 'Workspace changed after export') {
+        return fail(res, error.message, 409);
+      }
+      if (error instanceof jwt.JsonWebTokenError || error instanceof jwt.TokenExpiredError) {
+        return fail(res, 'Invalid reset authorization', 401);
+      }
+      return next(error);
+    }
+  });
+
+  app.get('/api/mvp/workspace/recovery/latest', async (req: AuthenticatedRequest, res, next) => {
+    try {
+      await repository.ensureUser(req.authUser!);
+      const recovery = await repository.getLatestRecovery(req.authUser!.id);
+      return recovery ? ok(res, recovery) : fail(res, 'No workspace recovery available', 404);
+    } catch (error) {
+      return next(error);
+    }
+  });
+
+  app.post('/api/mvp/workspace/recovery', recoveryLimiter, portableWorkspaceJsonParser, async (req: AuthenticatedRequest, res, next) => {
+    try {
+      const input = parseRequest(workspaceRecoveryRequestSchema, req.body, res);
+      if (!input) return;
+      if (!(await bcrypt.compare(input.password, req.authUser!.passwordHash))) {
+        return fail(res, 'Password reauthentication failed', 401);
+      }
+      await repository.ensureUser(req.authUser!);
+      return ok(res, await repository.restoreWorkspace(req.authUser!.id, input.export));
+    } catch (error) {
+      return next(error);
     }
   });
 

--- a/api/mvpRepository.ts
+++ b/api/mvpRepository.ts
@@ -3,6 +3,14 @@ import path from 'node:path';
 
 import type { StoredUser } from './authRepository';
 import type { MvpRepository } from './mvpRepository.types';
+import {
+  createWorkspaceExport,
+  digestWorkspace,
+  normalizeWorkspace,
+  workspaceExportSchema,
+  type MvpWorkspaceExport,
+  type MvpWorkspaceRecovery,
+} from './workspaceRecovery';
 
 import { generateWeeklyPlan } from '../shared/mvp/plan';
 import {
@@ -22,6 +30,7 @@ import type {
 
 interface PersistedMvpStore {
   users: Record<string, MvpWorkspaceSnapshot>;
+  recoveries: Record<string, MvpWorkspaceRecovery[]>;
 }
 
 const DEFAULT_DATA_FILE = path.join(process.cwd(), '.data', 'mvp-workspace.json');
@@ -37,7 +46,15 @@ function buildSnapshot(snapshot: MvpWorkspaceSnapshot): MvpWorkspaceSnapshot {
 }
 
 export class FileBackedMvpRepository implements MvpRepository {
+  private mutationQueue: Promise<void> = Promise.resolve();
+
   constructor(private readonly dataFilePath = process.env.MVP_DATA_FILE || DEFAULT_DATA_FILE) {}
+
+  private runMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.mutationQueue.then(operation, operation);
+    this.mutationQueue = result.then(() => undefined, () => undefined);
+    return result;
+  }
 
   async ensureUser(_user: StoredUser): Promise<void> {
     return Promise.resolve();
@@ -209,28 +226,69 @@ export class FileBackedMvpRepository implements MvpRepository {
     }));
   }
 
-  async resetWorkspace(userId: string): Promise<MvpWorkspaceSnapshot> {
-    return this.updateWorkspace(userId, () => defaultWorkspace());
+  async exportWorkspace(userId: string): Promise<MvpWorkspaceExport> {
+    return createWorkspaceExport(await this.getWorkspace(userId));
+  }
+
+  async resetWorkspace(userId: string, preparedInput: MvpWorkspaceExport) {
+    return this.runMutation(async () => {
+      const parsed = workspaceExportSchema.parse(preparedInput);
+      const prepared = createWorkspaceExport(parsed.workspace, parsed.exportedAt);
+      const store = await this.readStore();
+      const current = buildSnapshot(store.users[userId] ?? defaultWorkspace());
+      if (digestWorkspace(current) !== digestWorkspace(prepared.workspace)) {
+        throw new Error('Workspace changed after export');
+      }
+
+      const recovery: MvpWorkspaceRecovery = {
+        id: makeMvpId('recovery'),
+        export: prepared,
+      };
+      store.recoveries[userId] = [recovery, ...(store.recoveries[userId] ?? [])].slice(0, 5);
+      const workspace = defaultWorkspace();
+      store.users[userId] = workspace;
+      await this.writeStore(store);
+      return { workspace, recoveryId: recovery.id, export: recovery.export };
+    });
+  }
+
+  async getLatestRecovery(userId: string): Promise<MvpWorkspaceRecovery | null> {
+    const store = await this.readStore();
+    return store.recoveries[userId]?.[0] ?? null;
+  }
+
+  async restoreWorkspace(userId: string, portableExportInput: MvpWorkspaceExport) {
+    return this.runMutation(async () => {
+      const portableExport = workspaceExportSchema.parse(portableExportInput);
+      const restored = normalizeWorkspace(portableExport.workspace);
+      const store = await this.readStore();
+      store.users[userId] = restored;
+      await this.writeStore(store);
+      return restored;
+    });
   }
 
   private async updateWorkspace(
     userId: string,
     update: (workspace: MvpWorkspaceSnapshot) => MvpWorkspaceSnapshot
   ): Promise<MvpWorkspaceSnapshot> {
-    const store = await this.readStore();
-    const current = store.users[userId] ?? defaultWorkspace();
-    const next = buildSnapshot(update(current));
-    store.users[userId] = next;
-    await this.writeStore(store);
-    return next;
+    return this.runMutation(async () => {
+      const store = await this.readStore();
+      const current = store.users[userId] ?? defaultWorkspace();
+      const next = buildSnapshot(update(current));
+      store.users[userId] = next;
+      await this.writeStore(store);
+      return next;
+    });
   }
 
   private async readStore(): Promise<PersistedMvpStore> {
     try {
       const raw = await fs.readFile(this.dataFilePath, 'utf-8');
-      return JSON.parse(raw) as PersistedMvpStore;
+      const parsed = JSON.parse(raw) as Partial<PersistedMvpStore>;
+      return { users: parsed.users ?? {}, recoveries: parsed.recoveries ?? {} };
     } catch {
-      return { users: {} };
+      return { users: {}, recoveries: {} };
     }
   }
 

--- a/api/mvpRepository.types.ts
+++ b/api/mvpRepository.types.ts
@@ -7,6 +7,7 @@ import type {
   MvpReviewDraft,
   MvpWorkspaceSnapshot,
 } from '@/features/mvp/types';
+import type { MvpWorkspaceExport, MvpWorkspaceRecovery } from './workspaceRecovery';
 
 export interface MvpRepository {
   ensureUser(user: StoredUser): Promise<void>;
@@ -22,5 +23,11 @@ export interface MvpRepository {
   saveDailyCheckIn(userId: string, input: Omit<MvpDailyCheckIn, 'createdAt'>): Promise<MvpWorkspaceSnapshot>;
   addReflection(userId: string, input: Pick<MvpReflectionEntry, 'period' | 'body'>): Promise<MvpWorkspaceSnapshot>;
   submitFeedback(userId: string, input: { rating: number; message: string }): Promise<MvpWorkspaceSnapshot>;
-  resetWorkspace(userId: string): Promise<MvpWorkspaceSnapshot>;
+  exportWorkspace(userId: string): Promise<MvpWorkspaceExport>;
+  resetWorkspace(
+    userId: string,
+    prepared: MvpWorkspaceExport,
+  ): Promise<{ workspace: MvpWorkspaceSnapshot; recoveryId: string; export: MvpWorkspaceExport }>;
+  getLatestRecovery(userId: string): Promise<MvpWorkspaceRecovery | null>;
+  restoreWorkspace(userId: string, portableExport: MvpWorkspaceExport): Promise<MvpWorkspaceSnapshot>;
 }

--- a/api/prismaMvpRepository.ts
+++ b/api/prismaMvpRepository.ts
@@ -6,7 +6,7 @@ import { prisma as defaultPrisma } from './prisma';
 import type { MvpRepository } from './mvpRepository.types';
 
 import { generateWeeklyPlan } from '../shared/mvp/plan';
-import { createEmptyWorkspace, initialOnboardingDraft, initialReviewDraft, pushMvpEvent, withComputedAnalytics } from '../shared/mvp/state';
+import { createEmptyWorkspace, initialOnboardingDraft, initialReviewDraft, withComputedAnalytics } from '../shared/mvp/state';
 import type {
   MvpDailyCheckIn,
   MvpEvent,
@@ -17,6 +17,16 @@ import type {
   MvpReviewDraft,
   MvpWorkspaceSnapshot,
 } from '../shared/mvp/types';
+import {
+  createWorkspaceExport,
+  digestWorkspace,
+  normalizeWorkspace,
+  workspaceExportSchema,
+  type MvpWorkspaceExport,
+  type MvpWorkspaceRecovery,
+} from './workspaceRecovery';
+
+type WorkspaceDb = PrismaClient | Prisma.TransactionClient;
 
 function startOfWeek(date: Date) {
   const next = new Date(date);
@@ -115,6 +125,8 @@ function toJsonObject(value: unknown): Prisma.InputJsonValue {
 }
 
 export class PrismaBackedMvpRepository implements MvpRepository {
+  private readonly mutationQueues = new Map<string, Promise<void>>();
+
   constructor(private readonly db: PrismaClient = defaultPrisma) {}
 
   async ensureUser(user: StoredUser): Promise<void> {
@@ -139,6 +151,46 @@ export class PrismaBackedMvpRepository implements MvpRepository {
   }
 
   async saveOnboarding(userId: string, input: Omit<MvpOnboardingDraft, 'completedAt'>): Promise<MvpWorkspaceSnapshot> {
+    return this.runUserMutation(userId, () => this.saveOnboardingUnlocked(userId, input));
+  }
+
+  async generatePlan(userId: string, input: Omit<MvpReviewDraft, 'generatedAt' | 'id'>): Promise<MvpWorkspaceSnapshot> {
+    return this.runUserMutation(userId, () => this.generatePlanUnlocked(userId, input));
+  }
+
+  async confirmPlan(userId: string, planId: string): Promise<MvpWorkspaceSnapshot> {
+    return this.runUserMutation(userId, () => this.confirmPlanUnlocked(userId, planId));
+  }
+
+  async updateActionItem(
+    userId: string,
+    actionItemId: string,
+    patch: { status?: 'todo' | 'done' | 'deferred'; note?: string }
+  ): Promise<MvpWorkspaceSnapshot> {
+    return this.runUserMutation(userId, () => this.updateActionItemUnlocked(userId, actionItemId, patch));
+  }
+
+  async saveDailyCheckIn(userId: string, input: Omit<MvpDailyCheckIn, 'createdAt'>): Promise<MvpWorkspaceSnapshot> {
+    return this.runUserMutation(userId, () => this.saveDailyCheckInUnlocked(userId, input));
+  }
+
+  async addReflection(userId: string, input: Pick<MvpReflectionEntry, 'period' | 'body'>): Promise<MvpWorkspaceSnapshot> {
+    return this.runUserMutation(userId, () => this.addReflectionUnlocked(userId, input));
+  }
+
+  async submitFeedback(userId: string, input: { rating: number; message: string }): Promise<MvpWorkspaceSnapshot> {
+    return this.runUserMutation(userId, () => this.submitFeedbackUnlocked(userId, input));
+  }
+
+  async resetWorkspace(userId: string, preparedInput: MvpWorkspaceExport) {
+    return this.runUserMutation(userId, () => this.resetWorkspaceUnlocked(userId, preparedInput));
+  }
+
+  async restoreWorkspace(userId: string, portableExportInput: MvpWorkspaceExport): Promise<MvpWorkspaceSnapshot> {
+    return this.runUserMutation(userId, () => this.restoreWorkspaceUnlocked(userId, portableExportInput));
+  }
+
+  private async saveOnboardingUnlocked(userId: string, input: Omit<MvpOnboardingDraft, 'completedAt'>): Promise<MvpWorkspaceSnapshot> {
     const now = new Date();
     const existingProfile = await this.db.userProfile.findUnique({
       where: { userId },
@@ -224,7 +276,7 @@ export class PrismaBackedMvpRepository implements MvpRepository {
     return this.buildWorkspace(userId);
   }
 
-  async generatePlan(userId: string, input: Omit<MvpReviewDraft, 'generatedAt' | 'id'>): Promise<MvpWorkspaceSnapshot> {
+  private async generatePlanUnlocked(userId: string, input: Omit<MvpReviewDraft, 'generatedAt' | 'id'>): Promise<MvpWorkspaceSnapshot> {
     const onboarding = (await this.buildWorkspace(userId)).onboarding.completedAt
       ? (await this.buildWorkspace(userId)).onboarding
       : initialOnboardingDraft;
@@ -348,7 +400,7 @@ export class PrismaBackedMvpRepository implements MvpRepository {
     return this.buildWorkspace(userId);
   }
 
-  async confirmPlan(userId: string, planId: string): Promise<MvpWorkspaceSnapshot> {
+  private async confirmPlanUnlocked(userId: string, planId: string): Promise<MvpWorkspaceSnapshot> {
     const plan = await this.db.weeklyPlan.findFirst({
       where: {
         id: planId,
@@ -382,7 +434,7 @@ export class PrismaBackedMvpRepository implements MvpRepository {
     return this.buildWorkspace(userId);
   }
 
-  async updateActionItem(
+  private async updateActionItemUnlocked(
     userId: string,
     actionItemId: string,
     patch: { status?: 'todo' | 'done' | 'deferred'; note?: string }
@@ -419,7 +471,7 @@ export class PrismaBackedMvpRepository implements MvpRepository {
     return this.buildWorkspace(userId);
   }
 
-  async saveDailyCheckIn(userId: string, input: Omit<MvpDailyCheckIn, 'createdAt'>): Promise<MvpWorkspaceSnapshot> {
+  private async saveDailyCheckInUnlocked(userId: string, input: Omit<MvpDailyCheckIn, 'createdAt'>): Promise<MvpWorkspaceSnapshot> {
     const latestPlan = await this.db.weeklyPlan.findFirst({
       where: { userId },
       orderBy: [{ confirmedAt: 'desc' }, { updatedAt: 'desc' }],
@@ -476,7 +528,7 @@ export class PrismaBackedMvpRepository implements MvpRepository {
     return this.buildWorkspace(userId);
   }
 
-  async addReflection(userId: string, input: Pick<MvpReflectionEntry, 'period' | 'body'>): Promise<MvpWorkspaceSnapshot> {
+  private async addReflectionUnlocked(userId: string, input: Pick<MvpReflectionEntry, 'period' | 'body'>): Promise<MvpWorkspaceSnapshot> {
     const now = new Date();
     await this.db.$transaction([
       this.db.reflectionEntry.create({
@@ -502,7 +554,7 @@ export class PrismaBackedMvpRepository implements MvpRepository {
     return this.buildWorkspace(userId);
   }
 
-  async submitFeedback(userId: string, input: { rating: number; message: string }): Promise<MvpWorkspaceSnapshot> {
+  private async submitFeedbackUnlocked(userId: string, input: { rating: number; message: string }): Promise<MvpWorkspaceSnapshot> {
     const now = new Date();
     await this.db.$transaction([
       this.db.feedbackEntry.create({
@@ -531,29 +583,224 @@ export class PrismaBackedMvpRepository implements MvpRepository {
     return this.buildWorkspace(userId);
   }
 
-  async resetWorkspace(userId: string): Promise<MvpWorkspaceSnapshot> {
-    await this.db.$transaction([
-      this.db.mvpEventLog.deleteMany({ where: { userId } }),
-      this.db.dailyCheckIn.deleteMany({ where: { userId } }),
-      this.db.reflectionEntry.deleteMany({ where: { userId } }),
-      this.db.feedbackEntry.deleteMany({ where: { userId } }),
-      this.db.weeklyPlan.deleteMany({ where: { userId } }),
-      this.db.weeklyReview.deleteMany({ where: { userId } }),
-      this.db.goal.deleteMany({ where: { userId } }),
-      this.db.commitment.deleteMany({ where: { userId } }),
-      this.db.userProfile.deleteMany({ where: { userId } }),
-    ]);
-
-    return createEmptyWorkspace();
+  async exportWorkspace(userId: string): Promise<MvpWorkspaceExport> {
+    return createWorkspaceExport(await this.buildWorkspace(userId));
   }
 
-  private async buildWorkspace(userId: string): Promise<MvpWorkspaceSnapshot> {
-    const [profile, goals, commitments, review, plan, dailyCheckIns, reflections, feedback, events] = await this.db.$transaction([
-      this.db.userProfile.findUnique({ where: { userId } }),
-      this.db.goal.findMany({ where: { userId, active: true }, orderBy: { sortOrder: 'asc' } }),
-      this.db.commitment.findMany({ where: { userId, active: true }, orderBy: { createdAt: 'asc' } }),
-      this.db.weeklyReview.findFirst({ where: { userId }, orderBy: { updatedAt: 'desc' } }),
-      this.db.weeklyPlan.findFirst({
+  private async resetWorkspaceUnlocked(userId: string, preparedInput: MvpWorkspaceExport) {
+    const parsed = workspaceExportSchema.parse(preparedInput);
+    const prepared = createWorkspaceExport(parsed.workspace, parsed.exportedAt);
+    return this.db.$transaction(async (tx) => {
+      const current = await this.buildWorkspace(userId, tx);
+      if (digestWorkspace(current) !== digestWorkspace(prepared.workspace as MvpWorkspaceSnapshot)) {
+        throw new Error('Workspace changed after export');
+      }
+
+      const recovery = await tx.mvpWorkspaceRecovery.create({
+        data: {
+          userId,
+          format: prepared.format,
+          version: prepared.version,
+          exportedAt: new Date(prepared.exportedAt),
+          payload: toJsonObject(prepared),
+        },
+      });
+
+      await this.deleteWorkspace(userId, tx);
+      const expired = await tx.mvpWorkspaceRecovery.findMany({
+        where: { userId, id: { not: recovery.id } },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        skip: 4,
+        select: { id: true },
+      });
+      if (expired.length > 0) {
+        await tx.mvpWorkspaceRecovery.deleteMany({
+          where: { id: { in: expired.map(({ id }) => id) }, userId },
+        });
+      }
+
+      return { workspace: createEmptyWorkspace(), recoveryId: recovery.id, export: prepared };
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+  }
+
+  async getLatestRecovery(userId: string): Promise<MvpWorkspaceRecovery | null> {
+    const recovery = await this.db.mvpWorkspaceRecovery.findFirst({
+      where: { userId },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+    });
+    if (!recovery) return null;
+    return { id: recovery.id, export: workspaceExportSchema.parse(recovery.payload) };
+  }
+
+  private async restoreWorkspaceUnlocked(userId: string, portableExportInput: MvpWorkspaceExport): Promise<MvpWorkspaceSnapshot> {
+    const portableExport = workspaceExportSchema.parse(portableExportInput);
+    const workspace = normalizeWorkspace(portableExport.workspace as MvpWorkspaceSnapshot);
+    return this.db.$transaction(async (tx) => {
+      await this.deleteWorkspace(userId, tx);
+      await this.createWorkspace(userId, workspace, tx);
+      return this.buildWorkspace(userId, tx);
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+  }
+
+  private async deleteWorkspace(userId: string, tx: Prisma.TransactionClient) {
+    await tx.mvpEventLog.deleteMany({ where: { userId } });
+    await tx.dailyCheckIn.deleteMany({ where: { userId } });
+    await tx.reflectionEntry.deleteMany({ where: { userId } });
+    await tx.feedbackEntry.deleteMany({ where: { userId } });
+    await tx.weeklyPlan.deleteMany({ where: { userId } });
+    await tx.weeklyReview.deleteMany({ where: { userId } });
+    await tx.goal.deleteMany({ where: { userId } });
+    await tx.commitment.deleteMany({ where: { userId } });
+    await tx.userProfile.deleteMany({ where: { userId } });
+  }
+
+  private runUserMutation<T>(userId: string, operation: () => Promise<T>): Promise<T> {
+    const queued = this.mutationQueues.get(userId) ?? Promise.resolve();
+    const result = queued.then(operation, operation);
+    const settled = result.then(() => undefined, () => undefined);
+    this.mutationQueues.set(userId, settled);
+    void settled.then(() => {
+      if (this.mutationQueues.get(userId) === settled) {
+        this.mutationQueues.delete(userId);
+      }
+    });
+    return result;
+  }
+
+  private async createWorkspace(userId: string, workspace: MvpWorkspaceSnapshot, tx: Prisma.TransactionClient) {
+    const now = new Date();
+    await tx.userProfile.create({ data: {
+      userId,
+      displayName: workspace.onboarding.displayName,
+      role: workspace.onboarding.role || null,
+      lifeSeason: workspace.onboarding.lifeSeason || null,
+      planningPain: workspace.onboarding.planningPain || null,
+      successDefinition: workspace.onboarding.successDefinition || null,
+      onboardingConstraints: workspace.onboarding.constraints,
+      onboardingAt: workspace.onboarding.completedAt ? new Date(workspace.onboarding.completedAt) : null,
+    } });
+    if (workspace.onboarding.goals.length) {
+      await tx.goal.createMany({ data: workspace.onboarding.goals.map((title, sortOrder) => ({ userId, title, sortOrder })) });
+    }
+    if (workspace.onboarding.commitments.length) {
+      await tx.commitment.createMany({ data: workspace.onboarding.commitments.map((title) => ({ userId, title, kind: parseCommitmentKind(title) })) });
+    }
+
+    const reviewCreatedAt = workspace.review.generatedAt ? new Date(workspace.review.generatedAt) : now;
+    const weekStart = startOfWeek(reviewCreatedAt);
+    const weekEnd = endOfWeek(reviewCreatedAt);
+    let reviewId: string | undefined;
+    if (workspace.review.generatedAt) {
+      const review = await tx.weeklyReview.create({ data: {
+        id: workspace.review.id,
+        userId,
+        weekStart,
+        weekEnd,
+        wins: workspace.review.wins,
+        unfinishedWork: workspace.review.unfinishedWork,
+        constraints: workspace.review.constraints,
+        focusArea: workspace.review.focusArea || null,
+        energyLevel: workspace.review.energyLevel,
+        notes: workspace.review.notes || null,
+        createdAt: reviewCreatedAt,
+        updatedAt: reviewCreatedAt,
+      } });
+      reviewId = review.id;
+    }
+
+    if (workspace.plan.id) {
+      const planCreatedAt = workspace.plan.generatedAt ? new Date(workspace.plan.generatedAt) : now;
+      const planWeekStart = startOfWeek(planCreatedAt);
+      await tx.weeklyPlan.create({ data: {
+        id: workspace.plan.id,
+        userId,
+        weeklyReviewId: reviewId,
+        weekStart: planWeekStart,
+        weekEnd: endOfWeek(planCreatedAt),
+        status: workspace.plan.confirmedAt ? WeeklyPlanStatus.CONFIRMED : WeeklyPlanStatus.GENERATED,
+        summary: workspace.plan.summary,
+        generationSource: 'workspace_restore',
+        generationOutput: toJsonObject(workspace.plan),
+        confirmedAt: workspace.plan.confirmedAt ? new Date(workspace.plan.confirmedAt) : null,
+        createdAt: planCreatedAt,
+        updatedAt: planCreatedAt,
+        priorities: { create: workspace.plan.priorities.map((priority, sortOrder) => ({
+          id: priority.id,
+          title: priority.title,
+          rationale: priority.rationale || null,
+          successMetric: priority.successMetric || null,
+          status: PriorityStatus.ACTIVE,
+          sortOrder,
+          actionItems: { create: priority.actions.map((action, actionSortOrder) => ({
+            id: action.id,
+            title: action.title,
+            details: action.details || null,
+            status: toActionStatus(action.status),
+            note: action.note || null,
+            sortOrder: actionSortOrder,
+            createdAt: planCreatedAt,
+            updatedAt: planCreatedAt,
+          })) },
+        })) },
+      } });
+
+      if (workspace.dailyCheckIns.length) {
+        await tx.dailyCheckIn.createMany({ data: workspace.dailyCheckIns.map((entry) => ({
+          userId,
+          weeklyPlanId: workspace.plan.id!,
+          date: new Date(`${entry.date}T00:00:00.000Z`),
+          energy: entry.energy,
+          focus: entry.focus,
+          blockers: entry.blockers || null,
+          note: entry.note || null,
+          createdAt: new Date(entry.createdAt),
+          updatedAt: new Date(entry.createdAt),
+        })) });
+      }
+    }
+
+    if (workspace.reflections.length) {
+      await tx.reflectionEntry.createMany({ data: workspace.reflections.map((entry) => ({
+        id: entry.id,
+        userId,
+        period: entry.period === 'weekly' ? ReflectionPeriod.WEEKLY : ReflectionPeriod.DAILY,
+        body: entry.body,
+        createdAt: new Date(entry.createdAt),
+        updatedAt: new Date(entry.createdAt),
+      })) });
+    }
+    if (workspace.feedback.length) {
+      await tx.feedbackEntry.createMany({ data: workspace.feedback.map((entry) => ({
+        id: entry.id,
+        userId,
+        category: 'general',
+        rating: entry.rating,
+        message: entry.message,
+        source: 'workspace_restore',
+        createdAt: new Date(entry.createdAt),
+        updatedAt: new Date(entry.createdAt),
+      })) });
+    }
+    if (workspace.events.length) {
+      await tx.mvpEventLog.createMany({ data: workspace.events.map((event) => ({
+        id: event.id,
+        userId,
+        type: toMvpEventType(event.type),
+        createdAt: new Date(event.createdAt),
+      })) });
+    }
+  }
+
+  private async buildWorkspace(userId: string, db?: WorkspaceDb): Promise<MvpWorkspaceSnapshot> {
+    if (!db) {
+      return this.db.$transaction((tx) => this.buildWorkspace(userId, tx));
+    }
+    const [profile, goals, commitments, review, plan, dailyCheckIns, reflections, feedback, events] = await Promise.all([
+      db.userProfile.findUnique({ where: { userId } }),
+      db.goal.findMany({ where: { userId, active: true }, orderBy: { sortOrder: 'asc' } }),
+      db.commitment.findMany({ where: { userId, active: true }, orderBy: { createdAt: 'asc' } }),
+      db.weeklyReview.findFirst({ where: { userId }, orderBy: { updatedAt: 'desc' } }),
+      db.weeklyPlan.findFirst({
         where: { userId },
         orderBy: [{ confirmedAt: 'desc' }, { updatedAt: 'desc' }],
         include: {
@@ -567,10 +814,10 @@ export class PrismaBackedMvpRepository implements MvpRepository {
           },
         },
       }),
-      this.db.dailyCheckIn.findMany({ where: { userId }, orderBy: { createdAt: 'desc' } }),
-      this.db.reflectionEntry.findMany({ where: { userId }, orderBy: { createdAt: 'desc' } }),
-      this.db.feedbackEntry.findMany({ where: { userId }, orderBy: { createdAt: 'desc' } }),
-      this.db.mvpEventLog.findMany({ where: { userId }, orderBy: { createdAt: 'asc' } }),
+      db.dailyCheckIn.findMany({ where: { userId }, orderBy: { createdAt: 'desc' } }),
+      db.reflectionEntry.findMany({ where: { userId }, orderBy: { createdAt: 'desc' } }),
+      db.feedbackEntry.findMany({ where: { userId }, orderBy: { createdAt: 'desc' } }),
+      db.mvpEventLog.findMany({ where: { userId }, orderBy: { createdAt: 'asc' } }),
     ]);
 
     const onboarding: MvpOnboardingDraft = profile
@@ -654,10 +901,11 @@ export class PrismaBackedMvpRepository implements MvpRepository {
         message: entry.message,
         createdAt: entry.createdAt.toISOString(),
       })),
-      events: events.reduce<MvpEvent[]>((accumulator, event) => {
-        const type = fromMvpEventType(event.type);
-        return pushMvpEvent(accumulator, type, event.createdAt.toISOString());
-      }, []),
+      events: events.map<MvpEvent>((event) => ({
+        id: event.id,
+        type: fromMvpEventType(event.type),
+        createdAt: event.createdAt.toISOString(),
+      })),
     };
 
     return withComputedAnalytics(workspaceWithoutAnalytics);

--- a/api/requestSchemas.ts
+++ b/api/requestSchemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { workspaceExportSchema } from './workspaceRecovery';
 
 const shortText = (max: number) => z.string().trim().max(max);
 const requiredText = (max: number) => shortText(max).min(1);
@@ -76,3 +77,21 @@ export const feedbackRequestSchema = z.object({
 }).strict();
 
 export const emptyRequestSchema = z.object({}).strict();
+
+export const resetPreparationRequestSchema = z.object({
+  password: bcryptPassword(1),
+  confirmation: z.literal('RESET MY WORKSPACE'),
+}).strict();
+
+export const resetCommitRequestSchema = z.object({
+  password: bcryptPassword(1),
+  confirmation: z.literal('RESET MY WORKSPACE'),
+  resetToken: z.string().min(1).max(4_096),
+  export: workspaceExportSchema,
+}).strict();
+
+export const workspaceRecoveryRequestSchema = z.object({
+  password: bcryptPassword(1),
+  confirmation: z.literal('RESTORE MY WORKSPACE'),
+  export: workspaceExportSchema,
+}).strict();

--- a/api/workspaceRecovery.ts
+++ b/api/workspaceRecovery.ts
@@ -1,0 +1,200 @@
+import { createHash } from 'node:crypto';
+
+import { z } from 'zod';
+
+import { withComputedAnalytics } from '../shared/mvp/state';
+import type { MvpWorkspaceSnapshot } from '../shared/mvp/types';
+
+const text = (max: number) => z.string().max(max);
+const id = z.string().trim().min(1).max(128);
+const isoDateTime = z.string().datetime({ offset: true });
+const calendarDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine((value) => {
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}, 'Invalid calendar date');
+const rating = z.number().int().min(1).max(5);
+const itemList = z.array(text(300)).max(20);
+const eventType = z.enum([
+  'onboarding_started',
+  'onboarding_completed',
+  'weekly_review_started',
+  'weekly_review_completed',
+  'weekly_plan_generated',
+  'weekly_plan_confirmed',
+  'daily_checkin_completed',
+  'reflection_completed',
+  'user_feedback_submitted',
+]);
+
+const actionSchema = z.object({
+  id,
+  title: text(300),
+  details: text(2_000),
+  status: z.enum(['todo', 'done', 'deferred']),
+  note: text(2_000),
+}).strict();
+
+const prioritySchema = z.object({
+  id,
+  title: text(300),
+  rationale: text(2_000),
+  successMetric: text(300),
+  actions: z.array(actionSchema).max(100),
+}).strict();
+
+const workspaceSchema = z.object({
+  onboarding: z.object({
+    displayName: text(100),
+    role: text(200),
+    lifeSeason: text(200),
+    planningPain: text(2_000),
+    successDefinition: text(200),
+    goals: itemList,
+    commitments: itemList,
+    constraints: itemList,
+    completedAt: isoDateTime.nullable(),
+  }).strict(),
+  review: z.object({
+    id: id.optional(),
+    wins: itemList,
+    unfinishedWork: itemList,
+    constraints: itemList,
+    focusArea: text(200),
+    energyLevel: rating,
+    notes: text(2_000),
+    generatedAt: isoDateTime.nullable(),
+  }).strict(),
+  plan: z.object({
+    id: id.optional(),
+    summary: text(4_000),
+    weekLabel: text(100),
+    priorities: z.array(prioritySchema).max(20),
+    generatedAt: isoDateTime.nullable(),
+    confirmedAt: isoDateTime.nullable(),
+  }).strict(),
+  dailyCheckIns: z.array(z.object({
+    date: calendarDate,
+    energy: rating,
+    focus: rating,
+    blockers: text(2_000),
+    note: text(2_000),
+    createdAt: isoDateTime,
+  }).strict()).max(2_000),
+  reflections: z.array(z.object({
+    id,
+    period: z.enum(['daily', 'weekly']),
+    body: text(4_000),
+    createdAt: isoDateTime,
+  }).strict()).max(2_000),
+  feedback: z.array(z.object({
+    id,
+    rating,
+    message: text(4_000),
+    createdAt: isoDateTime,
+  }).strict()).max(2_000),
+  events: z.array(z.object({ id, type: eventType, createdAt: isoDateTime }).strict()).max(10_000),
+  analytics: z.object({
+    onboardingCompleted: z.boolean(),
+    weeklyPlanConfirmed: z.boolean(),
+    completedActions: z.number().int().nonnegative(),
+    totalActions: z.number().int().nonnegative(),
+    dailyCheckIns: z.number().int().nonnegative(),
+    reflections: z.number().int().nonnegative(),
+    feedbackEntries: z.number().int().nonnegative(),
+    eventCounts: z.record(eventType, z.number().int().nonnegative()),
+  }).strict(),
+}).strict().superRefine((workspace, context) => {
+  const ids = [
+    ...workspace.plan.priorities.flatMap((priority) => [priority.id, ...priority.actions.map((action) => action.id)]),
+    ...workspace.reflections.map((entry) => entry.id),
+    ...workspace.feedback.map((entry) => entry.id),
+    ...workspace.events.map((entry) => entry.id),
+  ];
+  if (new Set(ids).size !== ids.length) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Workspace IDs must be unique' });
+  }
+  const dates = workspace.dailyCheckIns.map((entry) => entry.date);
+  if (new Set(dates).size !== dates.length) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Daily check-in dates must be unique' });
+  }
+  if (workspace.dailyCheckIns.length > 0 && !workspace.plan.id) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Daily check-ins require a plan' });
+  }
+  if ((workspace.review.id === undefined) !== (workspace.review.generatedAt === null)) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Review ID and generation timestamp must appear together' });
+  }
+  if (!workspace.review.id && (
+    workspace.review.wins.length > 0
+    || workspace.review.unfinishedWork.length > 0
+    || workspace.review.constraints.length > 0
+    || workspace.review.focusArea !== ''
+    || workspace.review.energyLevel !== 3
+    || workspace.review.notes !== ''
+  )) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Review content requires a persisted review' });
+  }
+  if ((workspace.plan.id === undefined) !== (workspace.plan.generatedAt === null)) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Plan ID and generation timestamp must appear together' });
+  }
+  if (!workspace.plan.id && (workspace.plan.summary !== '' || workspace.plan.weekLabel !== '')) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Plan metadata requires a persisted plan' });
+  }
+  if (!workspace.plan.id && workspace.plan.priorities.length > 0) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Plan priorities require a plan' });
+  }
+  if (!workspace.plan.id && workspace.plan.confirmedAt !== null) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Plan confirmation requires a plan' });
+  }
+});
+
+const workspaceExportValidator = z.object({
+  format: z.literal('lifeos.mvp.workspace'),
+  version: z.literal(1),
+  exportedAt: isoDateTime,
+  workspace: workspaceSchema,
+}).strict().refine(
+  (value) => Buffer.byteLength(JSON.stringify(value), 'utf8') <= 8 * 1024 * 1024,
+  'Portable workspace export exceeds 8 MiB',
+);
+
+export interface MvpWorkspaceExport {
+  format: 'lifeos.mvp.workspace';
+  version: 1;
+  exportedAt: string;
+  workspace: MvpWorkspaceSnapshot;
+}
+
+export const workspaceExportSchema = workspaceExportValidator as unknown as z.ZodType<MvpWorkspaceExport>;
+
+export interface MvpWorkspaceRecovery {
+  id: string;
+  export: MvpWorkspaceExport;
+}
+
+export function normalizeWorkspace(workspace: MvpWorkspaceSnapshot): MvpWorkspaceSnapshot {
+  const parsed = workspaceSchema.parse(workspace);
+  const { analytics: _analytics, ...withoutAnalytics } = parsed;
+  void _analytics;
+  return withComputedAnalytics(withoutAnalytics as Omit<MvpWorkspaceSnapshot, 'analytics'>);
+}
+
+export function createWorkspaceExport(
+  workspace: MvpWorkspaceSnapshot,
+  exportedAt = new Date().toISOString(),
+): MvpWorkspaceExport {
+  return workspaceExportSchema.parse({
+    format: 'lifeos.mvp.workspace',
+    version: 1,
+    exportedAt,
+    workspace: normalizeWorkspace(workspace),
+  });
+}
+
+export function digestWorkspace(workspace: MvpWorkspaceSnapshot) {
+  return createHash('sha256').update(JSON.stringify(normalizeWorkspace(workspace))).digest('hex');
+}
+
+export function digestWorkspaceExport(portableExport: MvpWorkspaceExport) {
+  const normalized = createWorkspaceExport(portableExport.workspace, portableExport.exportedAt);
+  return createHash('sha256').update(JSON.stringify(normalized)).digest('hex');
+}

--- a/docs/mvp/route-map.md
+++ b/docs/mvp/route-map.md
@@ -119,5 +119,9 @@ These routes exist in `src/config/routes/index.tsx`, but they are not canonical 
 - Logout increments a persisted per-user session version, invalidating existing cookie and bearer tokens for that account.
 - Authentication is limited to 10 attempts per 15 minutes by direct peer, ordinary authenticated writes to 120 per 15 minutes per user, and plan generation to 20 per hour per user.
 - Express intentionally keeps `trust proxy=false`; forwarded client IP headers are not accepted in the supported direct deployment.
-- The current reset route is not yet the recoverable contract: #124 must replace it before parent #108 can close.
+- `POST /api/mvp/workspace/reset/export` requires password reauthentication plus exact `RESET MY WORKSPACE` confirmation and returns a versioned portable export with a ten-minute digest-bound reset token.
+- `POST /api/mvp/workspace/reset` repeats password and exact confirmation, verifies the prepared token, rejects changed workspaces with `409`, and retains recovery in the same repository mutation that clears the workspace.
+- `GET /api/mvp/workspace/recovery/latest` retrieves the latest retained user-scoped export; `POST /api/mvp/workspace/recovery` requires password plus exact `RESTORE MY WORKSPACE` and transactionally replaces the workspace from a strict envelope.
+- Reset and recovery each use an independent limit of three attempts per hour per user, including failed reauthentication or validation attempts. Recovery/reset payload routes allow at most 10 MiB after authentication/CSRF/limiting, with the strict envelope capped at 8 MiB, so a portable workspace can exceed the ordinary 32 KiB write limit without raising that global boundary.
+- The former bodyless `DELETE /api/mvp/workspace` and silent canonical web client/store reset are removed. Electron's separate reset bridge is non-canonical and remains explicitly owned by #111.
 - The route map should be treated as executable contract documentation, not as a proposal list. If a route is not implemented, do not document it here as current behavior.

--- a/docs/security/2026-07-16-operating-modes-threat-model.md
+++ b/docs/security/2026-07-16-operating-modes-threat-model.md
@@ -119,16 +119,18 @@ The shared validator in `shared/operatingMode.ts` is used by Vite and the Expres
 
 Observed controls: Helmet, credentialed CORS with an origin allowlist, strict bounded Zod schemas on every canonical auth/profile/MVP write, a 32 KiB JSON limit, bcrypt, signed expiring versioned JWTs, exact-Origin enforcement for unsafe cookie-authenticated methods, a 10-per-15-minute direct-peer auth limiter, a 120-per-15-minute per-user write limiter, and a 20-per-hour per-user plan-generation limiter. Bearer authorization is explicit authority rather than ambient browser state. Express intentionally keeps `trust proxy=false`; forwarded client-IP headers do not influence these limits in the supported direct topology.
 
+Observed destructive-recovery controls: canonical reset is two-step and password-reauthenticated, exact phrases are required, the prepared export is a strict versioned envelope, reset retains recovery atomically with deletion, stale preparation is rejected, and restore replaces the workspace transactionally. Reset and recovery have independent per-user throttles. The bodyless web reset surface is removed.
+
+The supported Prisma topology for this control is one Node.js application process. Workspace mutations are serialized per user inside that process; coordination across multiple processes or repository instances remains part of #109's durable concurrency decision and is not claimed here.
+
 Gaps that block partner-beta:
 
-- destructive reset still lacks password reauthentication, exact confirmation, a stricter destructive limiter, and a recoverable export contract; #124 owns this remaining parent requirement;
-- workspace reset immediately replaces the user's workspace and has no export, grace period or recovery contract;
 - the bearer-token response expands exposure beyond an HTTP-only cookie, although persisted global logout now revokes copied tokens;
 - the read-only admin overview uses an exact server-side email allowlist, but managed role lifecycle and cross-user/cohort administration are not implemented;
 - authentication errors reveal whether an invite is missing, claimed, or an account is registered; this is acceptable only for controlled invitation flows after abuse review;
 - auth file persistence can lose concurrent writes or expose a partial file after process interruption;
 - the MVP file repository treats any read or JSON parse failure as an empty store, so corruption can appear as data loss before a later write persists the empty state;
-- Prisma workspace reset is already grouped in a database transaction, but still lacks a user-facing confirmation, reauthentication and recovery contract.
+- retained workspace recovery covers the canonical visible MVP snapshot, not archived relational history, full account export/deletion, retention, or Electron data; #110 and #111 own those broader contracts.
 
 Before beta, validate every path/body/enum/string/date/rating at the HTTP boundary; set request-size and per-route rate limits; keep repository checks as defense in depth; require explicit confirmation plus a recoverable backup/export for workspace reset; and add CSRF protection appropriate to cookie-authenticated writes. Do not add a generic validation framework: Zod and `express-rate-limit` are already installed.
 

--- a/docs/superpowers/plans/2026-07-17-recoverable-workspace-reset.md
+++ b/docs/superpowers/plans/2026-07-17-recoverable-workspace-reset.md
@@ -1,0 +1,37 @@
+# Recoverable Workspace Reset Implementation Plan
+
+**Goal:** Make canonical workspace reset deliberate, exportable, and recoverable without expanding into account lifecycle or general persistence migration.
+
+**Architecture:** A strict portable envelope crosses the HTTP/repository boundary. Reset is prepared with password + exact phrase, authorized by a short-lived digest-bound token, and committed only if the workspace is unchanged. Each backend retains the recovery in the same mutation that clears data. Restore transactionally replaces the canonical workspace.
+
+**Dependencies:** Existing Zod, bcrypt, jsonwebtoken, express-rate-limit, Prisma, Vitest, Supertest, and Playwright only.
+
+## Task 1: Lock the HTTP contract red
+
+- Add schemas and tests for exact phrases, password bounds, strict envelope/version/invariants, CSRF, bodyless DELETE removal, digest conflict, reset/recovery rate limits, and failed reauthentication.
+- Add a response-loss test that retrieves the retained recovery after reset.
+
+## Task 2: Implement the portable contract
+
+- Add envelope types/schema, analytics recomputation, deterministic digesting, and short-lived reset token helpers.
+- Add the reset/export, reset commit, latest recovery, and recovery routes.
+- Mount a route-specific 1 MiB JSON parser for portable recovery while retaining the ordinary 32 KiB contract everywhere else.
+
+## Task 3: Implement repository atomicity
+
+- Extend `MvpRepository` with export, recoverable reset, latest recovery, and restore.
+- File: retain recovery + clear in one store write; restore by strict replace.
+- Prisma: add recovery model/migration; retain + delete in one transaction; restore dependencies in one transaction.
+- Add backend invariant and injected-failure tests.
+
+## Task 4: Remove stale canonical reset surfaces
+
+- Remove the bodyless reset method from the canonical web API/store and adjust test setup without hiding failures.
+- Document Electron reset as unresolved #111 scope, not equivalent recovery.
+- Update route map, threat model, and README.
+
+## Task 5: Verify and deliver
+
+- Run focused tests, Prisma integration tests, full suite, typecheck, lint, web/server builds, canonical E2E, and diff check.
+- Request independent data-safety/security review and final code review; resolve every material finding.
+- Commit with Lore trailers, push a draft PR closing #124, pass canonical gates, merge, validate #124, then close parent #108 only after auditing both children.

--- a/docs/superpowers/specs/2026-07-17-recoverable-workspace-reset-design.md
+++ b/docs/superpowers/specs/2026-07-17-recoverable-workspace-reset-design.md
@@ -1,0 +1,52 @@
+# Recoverable Workspace Reset Design
+
+## Scope
+
+Issue #124 replaces the canonical web `DELETE /api/mvp/workspace` with a two-step, password-reauthenticated reset. It does not implement full-account export/deletion (#110), general file atomicity or backup policy (#109), or Electron migration/recovery (#111).
+
+The lazier option is to remove reset entirely. It is rejected because the parent acceptance explicitly requires a usable, tested recovery path.
+
+## Portable envelope
+
+The shared envelope is strict and versioned:
+
+```ts
+{
+  format: 'lifeos.mvp.workspace',
+  version: 1,
+  exportedAt: string,
+  workspace: MvpWorkspaceSnapshot
+}
+```
+
+It contains no user ID, credential, invite, token, or password hash. The authenticated user supplies ownership. Strings, collections, IDs, ratings, dates, event types, and nested objects retain the canonical HTTP bounds; analytics is recomputed instead of trusted. Version or invariant mismatches fail before repository mutation. This envelope represents the canonical visible workspace, not archived relational history.
+
+## HTTP flow
+
+The exact reset phrase is `RESET MY WORKSPACE`; the exact restore phrase is `RESTORE MY WORKSPACE`. Matching is case-sensitive and whitespace-sensitive.
+
+1. `POST /api/mvp/workspace/reset/export` accepts password plus reset phrase, reauthenticates with bcrypt, and returns the envelope plus a short-lived signed reset token bound to the user and envelope digest.
+2. `POST /api/mvp/workspace/reset` accepts password, reset phrase, and reset token. It reauthenticates, verifies the token, and asks the repository to compare the prepared digest with the current workspace before resetting.
+3. In the same repository mutation/transaction, reset persists a retained recovery record and replaces the workspace with an empty snapshot. The response returns the empty workspace, recovery ID, and retained export.
+4. `GET /api/mvp/workspace/recovery/latest` returns the latest retained envelope after authentication.
+5. `POST /api/mvp/workspace/recovery` accepts password, restore phrase, and a portable envelope. It replaces the current workspace transactionally.
+
+Cookie requests inherit the exact-Origin policy from #123. Bearer requests remain explicit authority. Reset preparation/commit share a strict per-user limiter; recovery has a separate limiter. The recovery route alone receives a bounded 1 MiB JSON parser before the general 32 KiB parser because a complete history can exceed ordinary write size. Every nested value remains strictly validated.
+
+## Repository guarantees
+
+`MvpRepository` gains export, recoverable reset, latest recovery, and restore operations.
+
+- File-backed: the store document contains both workspaces and retained recoveries. Backup creation and clearing occur in one in-memory update followed by one store write. Broader temp-file/fsync/rename and multiprocess safety remain #109.
+- Prisma-backed: a versioned JSON recovery row is created in the same database transaction as all workspace deletes. Restore deletes current workspace rows and recreates the canonical snapshot in one transaction, preserving represented IDs/timestamps and relational dependencies.
+- Restore replaces rather than merges. Analytics is recomputed. A reset digest mismatch returns conflict and performs no mutation.
+
+A failed reset cannot destroy the only recoverable copy: the client already received the prepared envelope, and the repository creates its retained copy in the same mutation as deletion. If deletion rolls back, so does recovery creation and the original workspace remains.
+
+## Electron boundary
+
+The canonical web client/store loses its bodyless reset call. Electron's separate IPC/preload reset remains non-canonical and is explicitly owned by #111; it is not evidence that the web recovery contract covers desktop data.
+
+## Verification
+
+Tests must prove strict envelope validation, password and exact-phrase rejection, CSRF inheritance, separate destructive limits, no bodyless web reset, response-loss recovery through the retained copy, digest conflict, failure rollback, and export-reset-restore semantic equality for file and Prisma implementations. Full suite, typecheck, lint, web/server builds, canonical E2E, independent data-safety review, and final code review remain merge gates.

--- a/docs/superpowers/specs/2026-07-17-recoverable-workspace-reset-design.md
+++ b/docs/superpowers/specs/2026-07-17-recoverable-workspace-reset-design.md
@@ -26,12 +26,12 @@ It contains no user ID, credential, invite, token, or password hash. The authent
 The exact reset phrase is `RESET MY WORKSPACE`; the exact restore phrase is `RESTORE MY WORKSPACE`. Matching is case-sensitive and whitespace-sensitive.
 
 1. `POST /api/mvp/workspace/reset/export` accepts password plus reset phrase, reauthenticates with bcrypt, and returns the envelope plus a short-lived signed reset token bound to the user and envelope digest.
-2. `POST /api/mvp/workspace/reset` accepts password, reset phrase, and reset token. It reauthenticates, verifies the token, and asks the repository to compare the prepared digest with the current workspace before resetting.
+2. `POST /api/mvp/workspace/reset` accepts password, reset phrase, reset token, and the prepared export. It reauthenticates, verifies that the token digest matches that envelope, and asks the repository to compare the prepared digest with the current workspace before resetting.
 3. In the same repository mutation/transaction, reset persists a retained recovery record and replaces the workspace with an empty snapshot. The response returns the empty workspace, recovery ID, and retained export.
 4. `GET /api/mvp/workspace/recovery/latest` returns the latest retained envelope after authentication.
 5. `POST /api/mvp/workspace/recovery` accepts password, restore phrase, and a portable envelope. It replaces the current workspace transactionally.
 
-Cookie requests inherit the exact-Origin policy from #123. Bearer requests remain explicit authority. Reset preparation/commit share a strict per-user limiter; recovery has a separate limiter. The recovery route alone receives a bounded 1 MiB JSON parser before the general 32 KiB parser because a complete history can exceed ordinary write size. Every nested value remains strictly validated.
+Cookie requests inherit the exact-Origin policy from #123. Bearer requests remain explicit authority. Reset preparation/commit share a strict per-user limiter; recovery has a separate limiter. Reset commit and recovery receive a bounded 10 MiB parser only after authentication, CSRF, and rate limiting because a complete history can exceed ordinary write size; the envelope itself is capped at 8 MiB and every nested value remains strictly validated. The general 32 KiB parser remains unchanged.
 
 ## Repository guarantees
 

--- a/electron/ipc/__tests__/mvpHandler.test.ts
+++ b/electron/ipc/__tests__/mvpHandler.test.ts
@@ -166,4 +166,12 @@ describe('setupMvpHandlers', () => {
 
     expect(persisted.users?.['restored-desktop-user']?.onboarding?.displayName).toBe('Recovered')
   });
+
+  it('confines destructive desktop reset to the recovery work tracked in #111', async () => {
+    const resetWorkspace = mockState.handlers.get('mvp:resetWorkspace');
+
+    await expect(resetWorkspace?.({})).rejects.toThrow(
+      'Desktop workspace reset is disabled until the #111 recovery contract is implemented.',
+    );
+  });
 });

--- a/electron/ipc/mvpHandler.ts
+++ b/electron/ipc/mvpHandler.ts
@@ -102,7 +102,7 @@ export const setupMvpHandlers = (
     withDesktopWorkspace(repository, resolveUser, (repo, user) => repo.submitFeedback(user.id, input)),
   );
 
-  ipcMain.handle('mvp:resetWorkspace', async () =>
-    withDesktopWorkspace(repository, resolveUser, (repo, user) => repo.resetWorkspace(user.id)),
-  );
+  ipcMain.handle('mvp:resetWorkspace', async () => {
+    throw new Error('Desktop workspace reset is disabled until the #111 recovery contract is implemented.');
+  });
 };

--- a/prisma/migrations/20260717_120000_add_workspace_recovery/migration.sql
+++ b/prisma/migrations/20260717_120000_add_workspace_recovery/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "MvpWorkspaceRecovery" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "format" TEXT NOT NULL,
+    "version" INTEGER NOT NULL,
+    "exportedAt" TIMESTAMP(3) NOT NULL,
+    "payload" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MvpWorkspaceRecovery_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MvpWorkspaceRecovery_userId_createdAt_idx" ON "MvpWorkspaceRecovery"("userId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "MvpWorkspaceRecovery" ADD CONSTRAINT "MvpWorkspaceRecovery_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,20 @@ model User {
   reflectionEntries ReflectionEntry[]
   feedbackEntries   FeedbackEntry[]
   mvpEvents         MvpEventLog[]
+  workspaceRecoveries MvpWorkspaceRecovery[]
+}
+
+model MvpWorkspaceRecovery {
+  id         String   @id @default(cuid())
+  userId     String
+  format     String
+  version    Int
+  exportedAt DateTime
+  payload    Json
+  createdAt  DateTime @default(now())
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, createdAt])
 }
 
 model UserProfile {

--- a/src/features/mvp/__tests__/MvpLoop.int.test.tsx
+++ b/src/features/mvp/__tests__/MvpLoop.int.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { MvpSurfacePage } from '@/features/mvp/pages/MvpSurfacePage';
 import { useMvpStore } from '@/features/mvp/store/useMvpStore';
+import { createEmptyWorkspace } from '@/features/mvp/lib/state';
 
 function renderSurface(surface: Parameters<typeof MvpSurfacePage>[0]['surface']) {
   return render(
@@ -15,10 +16,10 @@ function renderSurface(surface: Parameters<typeof MvpSurfacePage>[0]['surface'])
 }
 
 describe('MVP loop integration', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     localStorage.clear();
     window.gtag = vi.fn() as typeof window.gtag;
-    await useMvpStore.getState().resetWorkspace();
+    useMvpStore.setState({ ...createEmptyWorkspace(), isHydrating: false, error: null });
   });
 
   it('moves through the MVP loop and emits production telemetry events', { timeout: 15000 }, async () => {

--- a/src/features/mvp/api/mvp.api.ts
+++ b/src/features/mvp/api/mvp.api.ts
@@ -37,7 +37,6 @@ function getDesktopMvpBridge() {
     saveDailyCheckIn: (input: Omit<MvpDailyCheckIn, 'createdAt'>) => Promise<MvpWorkspaceSnapshot>;
     addReflection: (input: Omit<MvpReflectionEntry, 'id' | 'createdAt'>) => Promise<MvpWorkspaceSnapshot>;
     submitFeedback: (input: { rating: number; message: string }) => Promise<MvpWorkspaceSnapshot>;
-    resetWorkspace: () => Promise<MvpWorkspaceSnapshot>;
   };
 }
 
@@ -122,12 +121,4 @@ export const mvpApi = {
     return unwrap(await apiClient.post<ApiResponse<MvpWorkspaceSnapshot>>('/api/mvp/feedback', input));
   },
 
-  resetWorkspace: async () => {
-    const desktopBridge = getDesktopMvpBridge();
-    if (desktopBridge) {
-      return desktopBridge.resetWorkspace();
-    }
-
-    return unwrap(await apiClient.delete<ApiResponse<MvpWorkspaceSnapshot>>('/api/mvp/workspace'));
-  },
 };

--- a/src/features/mvp/store/useMvpStore.ts
+++ b/src/features/mvp/store/useMvpStore.ts
@@ -31,7 +31,6 @@ export interface MvpStoreState extends MvpWorkspaceSnapshot {
   saveDailyCheckIn: (input: Omit<MvpDailyCheckIn, 'createdAt'>) => Promise<void>;
   addReflection: (period: 'daily' | 'weekly', body: string) => Promise<void>;
   submitFeedback: (rating: number, message: string) => Promise<void>;
-  resetWorkspace: () => Promise<void>;
   getAnalytics: () => MvpAnalyticsSnapshot;
 }
 
@@ -185,19 +184,6 @@ export const useMvpStore = create<MvpStoreState>()((set, get) => ({
       const detail = error instanceof Error ? error.message : 'Failed to submit feedback.';
       captureMvpError(error, 'submit_feedback', { rating });
       set({ error: detail });
-    }
-  },
-
-  resetWorkspace: async () => {
-    try {
-      const snapshot = await mvpApi.resetWorkspace();
-      set(applyWorkspace(snapshot));
-    } catch {
-      set({
-        ...createInitialState(),
-        isHydrating: false,
-        error: null,
-      });
     }
   },
 


### PR DESCRIPTION
## Summary
- replace the canonical bodyless reset with password reauthentication, exact confirmation, CSRF, and a digest-bound portable export
- retain and restore strict versioned recoveries in file and Prisma repositories, with same-process mutation serialization
- confine Electron reset to #111 and document #109 as the owner of cross-process durability

## Verification
- focused recovery contract: 21 passed
- full Vitest suite: passed
- typecheck: passed
- lint: 0 errors, 9 pre-existing warnings
- Prisma schema validation: passed
- server build: passed
- local-dev web build: passed
- independent security/data-loss review: passed
- independent final code review: passed

## Limits
- multi-process coordination and live restore drills remain in #109
- TestSprite is an external/non-canonical limitation and is not changed here

Closes #124