### PR TITLE
security: sanitize persisted and exported sync diagnostics

### DIFF
--- a/docs/privacy/personal-data-lifecycle.md
+++ b/docs/privacy/personal-data-lifecycle.md
@@ -27,7 +27,7 @@ This is the enforceable lifecycle for the canonical web MVP. Experimental Electr
 | MVP event names/timestamps and computed counts | product behavior and in-product summaries | selected MVP repository | account lifetime | workspace JSON envelope | removed |
 | Up to five workspace recovery envelopes | recovery after explicit workspace reset | selected MVP repository | until replaced by the five-record cap or account deletion | included in account export | removed |
 | Theme, language, accessibility, onboarding, focus, sanctuary, dynamic-now and user preferences | device experience | browser local storage, guarded by the current account owner marker | until account transition, local clear or account deletion from Settings | added only when the owner marker matches the authenticated account | known LifeOS keys and owner marker are removed |
-| Local sync diagnostics | legacy synchronization status; entries may contain free-text messages or raw error details | browser IndexedDB, capped at 100 entries | until local clear or account deletion | added to downloaded JSON by the browser; inspect before sharing | removed by the Settings deletion flow |
+| Local sync diagnostics | allowlisted synchronization outcome only | browser IndexedDB, capped at 100 entries | until local clear or account deletion | sanitized to id, timestamp, type and a fixed message; legacy arbitrary fields are discarded | removed by the Settings deletion flow |
 | Auth/session state and query cache | offline continuity | browser IndexedDB and local storage | until logout/cache expiry or account deletion | never portable because it can contain credentials/duplicates | removed by the Settings deletion flow |
 
 Derived analytics in the workspace are recomputed from exported records. They are not an independent processor or retention store.
@@ -52,7 +52,7 @@ Run restore drills only in a disposable isolated database, verify user scoping a
 ## Logs and processors
 
 - The canonical Express request-error middleware emits only `MVP API request failed`; request bodies and exception objects are not logged there.
-- The canonical browser error boundary retains only allowlisted name/code and fixed component/action labels. The legacy local sync-log store is a known exception: it may persist/export free-text messages and raw error details, so #138 owns sanitization and exports must be inspected before sharing.
+- The canonical browser error boundary retains only allowlisted name/code and fixed component/action labels. Sync diagnostics store only a fixed message per allowlisted outcome; account export re-sanitizes legacy entries and discards arbitrary fields.
 - Authentication UI does not log email, user agent, credentials or raw errors.
 - Host logs, if retained, expire within 7 days and are accessible only to the maintainer.
 

--- a/docs/security/2026-07-16-operating-modes-threat-model.md
+++ b/docs/security/2026-07-16-operating-modes-threat-model.md
@@ -155,7 +155,7 @@ Partner-beta requires:
 
 ## Observability and privacy
 
-Logs must not contain passwords, invite codes, session/bearer tokens, raw request bodies, reflection text or third-party secret values. Canonical browser and Express error boundaries emit only stable allowlisted labels or a fixed failure message. The legacy device-local sync-log store is a documented exception that may persist/export free-text or raw error details; #138 must sanitize it before partner-beta. External telemetry SDK initialization and transports are absent from supported MVP builds.
+Logs must not contain passwords, invite codes, session/bearer tokens, raw request bodies, reflection text or third-party secret values. Canonical browser and Express error boundaries emit only stable allowlisted labels or a fixed failure message. Device-local sync diagnostics now persist fixed outcome messages only, and export re-sanitizes legacy entries before inclusion. External telemetry SDK initialization and transports are absent from supported MVP builds.
 
 Sentry, analytics, source maps and vendor UI are disabled for supported shared modes until their exact payload, legal basis/consent where applicable, retention, access owner and deletion process are documented. Source maps may be uploaded privately to an error service after review; they should not be publicly served by default.
 
@@ -169,7 +169,7 @@ Issues #106-#111 delivered and validated the repository controls below. Their co
 | #107 | server-side exact-email read-only admin authorization | managed role lifecycle before beta |
 | #108 | schemas, limits, session/Origin controls and recoverable reset | deployed abuse/edge evidence |
 | #109 | atomic file stores plus tested file-to-Prisma migration/rollback | multi-process topology and live restore drill |
-| #110 | web export, deletion, retention and processor contract | operational request/incident handling; #138 legacy sync-log sanitization |
+| #110/#138 | web export, deletion, retention, processor contract and sync-log sanitization | operational request/incident handling |
 | #111 | Electron token confinement and token-free preservation export | no supported import/reset; runtime remains experimental |
 
 The lazier safe path is to keep beta unsupported and collect the controlled-demo deployment evidence only when a real demonstration is scheduled.

--- a/src/features/settings/components/DataLifecycleTab.test.ts
+++ b/src/features/settings/components/DataLifecycleTab.test.ts
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { beforeEach, expect, it, vi } from 'vitest';
-import { del } from 'idb-keyval';
+import { del, get } from 'idb-keyval';
 
 import { clearPrivateClientData, preparePrivateClientDataForUser, withClientData } from '@/shared/privacy/clientData';
 import { persister } from '@/shared/lib/react-query';
@@ -51,6 +51,27 @@ it('does not export a previous user global browser state after account switching
 
   expect(JSON.stringify(await withClientData(serverExport, 'user-b'))).not.toContain('User A');
   expect(localStorage.getItem('user_preferences:user-a')).toBeNull();
+});
+
+it('sanitizes legacy sync diagnostics before adding them to an account export', async () => {
+  await preparePrivateClientDataForUser('user-1');
+  vi.mocked(get).mockResolvedValueOnce({ state: { logs: [{
+    id: 'legacy-id', timestamp: 123, type: 'error',
+    message: 'private user content at https://private.example/path',
+    details: { stack: 'secret stack', token: 'private-token' },
+    table: 'tasks/user@example.test', method: 'GET /private/path',
+  }] }, version: 0 });
+  const serverExport = {
+    format: 'lifeos.account.export' as const, version: 1 as const, exportedAt: '2026-07-18T00:00:00.000Z',
+    account: { id: 'user-1' }, workspace: {}, identityMappingClaims: [],
+  };
+
+  const exported = await withClientData(serverExport, 'user-1');
+
+  expect(exported.client.syncLogs).toEqual({ logs: [{
+    id: 'legacy-id', timestamp: 123, type: 'error', message: 'Synchronization failed',
+  }] });
+  expect(JSON.stringify(exported)).not.toMatch(/private|secret|token|user@example/);
 });
 
 it('leaves new account data unowned when account-transition cleanup is incomplete', async () => {

--- a/src/features/tasks/hooks/useTasks.ts
+++ b/src/features/tasks/hooks/useTasks.ts
@@ -32,9 +32,7 @@ export function useTasks() {
                 // Log to our new sync store for visibility in UI
                 import('@/shared/stores/useSyncLogStore').then(m => {
                     m.useSyncLogStore.getState().addLog({
-                        type: 'error',
-                        message: `Falha ao carregar tarefas: ${error.message || 'Erro de rede'}`,
-                        details: error
+                        type: 'error'
                     });
                 });
                 throw error;

--- a/src/shared/privacy/clientData.ts
+++ b/src/shared/privacy/clientData.ts
@@ -4,6 +4,7 @@ import type { PersonalDataExport } from '@/features/auth/api/auth.api';
 import { clearAuthToken } from '@/shared/api/authToken';
 import { queryClient, persister } from '@/shared/lib/react-query';
 import { useAuthStore } from '@/shared/stores/authStore';
+import { sanitizePersistedSyncLogs } from '@/shared/privacy/syncLogPrivacy';
 
 const OWNER_KEY = 'lifeos-private-owner';
 const privateKeys = (userId: string) => [
@@ -52,11 +53,12 @@ export async function preparePrivateClientDataForUser(userId: string) {
 
 export async function withClientData(serverExport: PersonalDataExport, userId: string) {
   const owned = localStorage.getItem(OWNER_KEY) === userId;
+  const syncLogs = owned ? sanitizePersistedSyncLogs(await get('sync-logs-storage')) : null;
   return {
     ...serverExport,
     client: owned ? {
       localStorage: Object.fromEntries(privateKeys(userId).map((key) => [key, localStorage.getItem(key)])),
-      syncLogs: await get('sync-logs-storage') ?? null,
+      syncLogs,
     } : { localStorage: {}, syncLogs: null },
   };
 }

--- a/src/shared/privacy/syncLogPrivacy.ts
+++ b/src/shared/privacy/syncLogPrivacy.ts
@@ -1,0 +1,34 @@
+export type SyncLogType = 'success' | 'error' | 'retry';
+
+export interface SanitizedSyncLogEntry {
+  id?: string;
+  timestamp?: number;
+  type: SyncLogType;
+  message: string;
+}
+
+const messages: Record<SyncLogType, string> = {
+  success: 'Synchronization completed',
+  error: 'Synchronization failed',
+  retry: 'Synchronization retry scheduled',
+};
+
+export function sanitizeSyncLogEntry(value: unknown): SanitizedSyncLogEntry | null {
+  if (!value || typeof value !== 'object') return null;
+  const entry = value as Record<string, unknown>;
+  if (entry.type !== 'success' && entry.type !== 'error' && entry.type !== 'retry') return null;
+
+  const sanitized: SanitizedSyncLogEntry = { type: entry.type, message: messages[entry.type] };
+  if (typeof entry.id === 'string' && /^[a-zA-Z0-9_-]{1,64}$/.test(entry.id)) sanitized.id = entry.id;
+  if (typeof entry.timestamp === 'number' && Number.isFinite(entry.timestamp) && entry.timestamp >= 0) {
+    sanitized.timestamp = entry.timestamp;
+  }
+  return sanitized;
+}
+
+export function sanitizePersistedSyncLogs(value: unknown): { logs: SanitizedSyncLogEntry[] } {
+  const root = value && typeof value === 'object' ? value as Record<string, unknown> : {};
+  const state = root.state && typeof root.state === 'object' ? root.state as Record<string, unknown> : root;
+  const logs = Array.isArray(state.logs) ? state.logs : [];
+  return { logs: logs.slice(0, 100).map(sanitizeSyncLogEntry).filter((entry): entry is SanitizedSyncLogEntry => entry !== null) };
+}

--- a/src/shared/stores/useSyncLogStore.test.ts
+++ b/src/shared/stores/useSyncLogStore.test.ts
@@ -1,0 +1,56 @@
+/** @vitest-environment jsdom */
+import { beforeEach, expect, it, vi } from 'vitest';
+import { get, set } from 'idb-keyval';
+
+vi.mock('idb-keyval', () => ({
+  get: vi.fn().mockResolvedValue(null),
+  set: vi.fn().mockResolvedValue(undefined),
+  del: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { useSyncLogStore } from './useSyncLogStore';
+import { sanitizePersistedSyncLogs } from '@/shared/privacy/syncLogPrivacy';
+
+beforeEach(() => useSyncLogStore.setState({ logs: [] }));
+
+it('stores only a fixed diagnostic message and no raw error details', () => {
+  (useSyncLogStore.getState().addLog as (entry: unknown) => void)({
+    type: 'error',
+    message: 'request failed for user@example.test at https://private.example/path',
+    details: { stack: 'secret stack', token: 'private-token' },
+    table: 'tasks/user@example.test',
+    method: 'GET https://private.example/path',
+  });
+
+  expect(useSyncLogStore.getState().logs[0]).toMatchObject({
+    type: 'error',
+    message: 'Synchronization failed',
+  });
+  expect(useSyncLogStore.getState().logs[0]).not.toHaveProperty('details');
+  expect(useSyncLogStore.getState().logs[0]).not.toHaveProperty('table');
+  expect(useSyncLogStore.getState().logs[0]).not.toHaveProperty('method');
+});
+
+it('does not inspect persisted entries beyond the 100-entry retention cap', () => {
+  const logs = Array.from({ length: 101 }, () => ({ type: 'success' }));
+  Object.defineProperty(logs, 100, { get: () => { throw new Error('entry beyond cap was read'); } });
+
+  expect(sanitizePersistedSyncLogs({ state: { logs } }).logs).toHaveLength(100);
+});
+
+it('rewrites legacy persisted entries through the allowlisted schema during hydration', async () => {
+  vi.mocked(get).mockResolvedValueOnce({ metadata: { url: 'https://private.example' }, state: { token: 'private-token', logs: [{
+    id: 'legacy-id', timestamp: 123, type: 'error', message: 'private content',
+    details: { token: 'private-token' },
+  }] }, version: 0 });
+
+  await useSyncLogStore.persist.rehydrate();
+
+  expect(useSyncLogStore.getState().logs).toEqual([{
+    id: 'legacy-id', timestamp: 123, type: 'error', message: 'Synchronization failed',
+  }]);
+  expect(set).toHaveBeenCalledWith('sync-logs-storage', {
+    state: { logs: [{ id: 'legacy-id', timestamp: 123, type: 'error', message: 'Synchronization failed' }] },
+    version: 0,
+  });
+});

--- a/src/shared/stores/useSyncLogStore.ts
+++ b/src/shared/stores/useSyncLogStore.ts
@@ -1,31 +1,35 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { get, set, del } from 'idb-keyval';
+import { sanitizePersistedSyncLogs, sanitizeSyncLogEntry, type SanitizedSyncLogEntry, type SyncLogType } from '@/shared/privacy/syncLogPrivacy';
 
-export interface SyncLogEntry {
-  id: string;
-  timestamp: number;
-  type: 'success' | 'error' | 'retry';
-  message: string;
-  details?: string | Record<string, unknown>;
-  table?: string;
-  method?: string;
-}
+export interface SyncLogEntry extends SanitizedSyncLogEntry { id: string; timestamp: number; }
 
 interface SyncLogState {
   logs: SyncLogEntry[];
-  addLog: (entry: Omit<SyncLogEntry, 'id' | 'timestamp'>) => void;
+  addLog: (entry: { type: SyncLogType }) => void;
   clearLogs: () => void;
 }
 
 // IndexedDB storage for logs (can be large)
+function sanitizeEnvelope(value: unknown) {
+  const envelope = value && typeof value === 'object' ? value as Record<string, unknown> : {};
+  const version = typeof envelope.version === 'number' && Number.isInteger(envelope.version) && envelope.version >= 0
+    ? envelope.version
+    : 0;
+  return { state: sanitizePersistedSyncLogs(value), version };
+}
+
 const storage = {
   getItem: async (name: string): Promise<string | null> => {
     const value = await get(name);
-    return value ? JSON.stringify(value) : null;
+    if (!value || typeof value !== 'object') return null;
+    const sanitized = sanitizeEnvelope(value);
+    await set(name, sanitized);
+    return JSON.stringify(sanitized);
   },
   setItem: async (name: string, value: string): Promise<void> => {
-    await set(name, JSON.parse(value));
+    await set(name, sanitizeEnvelope(JSON.parse(value)));
   },
   removeItem: async (name: string): Promise<void> => {
     await del(name);
@@ -37,8 +41,10 @@ export const useSyncLogStore = create<SyncLogState>()(
     (set) => ({
       logs: [],
       addLog: (entry) => set((state) => {
+        const sanitized = sanitizeSyncLogEntry(entry);
+        if (!sanitized) return state;
         const newLog = {
-          ...entry,
+          ...sanitized,
           id: Math.random().toString(36).substring(2, 9),
           timestamp: Date.now(),
         };


### PR DESCRIPTION
## Problem

The legacy sync-log store accepted arbitrary error messages/objects and account export copied its raw IndexedDB envelope. URLs, stacks, user content, tokens or unknown metadata could therefore persist locally and leave the device in a downloaded export.

## Solution

- replace free-form entries with fixed messages for three allowlisted outcomes;
- persist only `id`, `timestamp`, `type` and fixed `message`;
- reconstruct the Zustand envelope from only `{state:{logs},version}` on read/write;
- cap legacy input before inspection, drop malformed entries and rewrite sanitized state during hydration;
- re-sanitize owner-gated legacy data during account export;
- update privacy/threat-model facts.

## TDD evidence

Three RED failures were observed before each implementation slice: raw new writes, raw legacy hydration/export, and inspection beyond the 100-entry cap. The final focused suite is 8/8 green.

## Verification

- typecheck
- lint: 0 errors; 9 unrelated baseline warnings
- full suite: 92 files, 747 passed, 63 skipped
- focused post-hardening regression: 8/8
- independent security and compatibility reviews: PASS

## Risk and rollback

Users lose free-form sync error detail by design; fixed outcome/timestamp diagnostics remain. Revert commit `ca3636b` to restore the prior behavior, but that reopens the privacy finding. No server or account data migration.

## Out of scope

No external telemetry, logging framework or supported-mode expansion.

Closes #138

## Summary by Sourcery

Sanitizar os diagnósticos de sincronização locais ao dispositivo para remover detalhes de erros brutos e garantir que apenas resultados fixos e pré-autorizados sejam armazenados e exportados.

Correções de bugs:
- Impedir que registros de sincronização legados e novos persistam detalhes de erros brutos, URLs, conteúdo do usuário ou tokens, aplicando um esquema pré-autorizado.

Melhorias:
- Normalizar os diagnósticos de sincronização para mensagens fixas contendo apenas id, timestamp e tipo, sanitizando os envelopes na leitura/gravação e durante a hidratação.
- Re-sanitizar os diagnósticos de sincronização com escopo de proprietário durante a exportação da conta, para que o JSON baixado não possa incluir campos legados sensíveis.
- Documentar o comportamento atualizado e o modelo de ameaça para diagnósticos de sincronização na documentação de privacidade e segurança.

Testes:
- Adicionar testes de unidade cobrindo a sanitização dos registros de sincronização, reescrita da hidratação legada, re-sanitização na exportação e aplicação do limite de retenção de 100 entradas.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Sanitize device-local sync diagnostics to remove raw error details and ensure only fixed, allowlisted outcomes are stored and exported.

Bug Fixes:
- Prevent legacy and new sync log entries from persisting raw error details, URLs, user content or tokens by enforcing an allowlisted schema.

Enhancements:
- Normalize sync diagnostics to fixed messages with only id, timestamp and type, sanitizing envelopes on read/write and during hydration.
- Re-sanitize owner-scoped sync diagnostics during account export so downloaded JSON cannot include legacy sensitive fields.
- Document the updated behavior and threat model for sync diagnostics in privacy and security docs.

Tests:
- Add unit tests covering sync log sanitization, legacy hydration rewriting, export re-sanitization and enforcement of the 100-entry retention cap.

</details>

Correções de bugs:
- Impedir que entradas de log de sincronização legadas e novas armazenem detalhes brutos de erros ou conteúdo do usuário, aplicando um esquema estritamente baseado em lista de permissão (allowlist).

Melhorias:
- Normalizar entradas de log de sincronização para mensagens de resultado fixas e apenas IDs/carimbos de data e hora, e sanitizar envelopes persistidos em operações de leitura/gravação.
- Re-sanitizar diagnósticos de sincronização com escopo de proprietário durante a exportação de conta, de modo que o JSON baixado não possa incluir campos legados sensíveis.
- Atualizar a documentação de privacidade e segurança para refletir o novo comportamento dos diagnósticos de sincronização e as responsabilidades do modelo de ameaças.

Testes:
- Adicionar testes de unidade para verificar a sanitização do log de sincronização, reescrita de hidratação legada, re-sanitização na exportação e aplicação de limites de retenção.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Sanitizar os diagnósticos de sincronização locais ao dispositivo para remover detalhes de erros brutos e garantir que apenas resultados fixos e pré-autorizados sejam armazenados e exportados.

Correções de bugs:
- Impedir que registros de sincronização legados e novos persistam detalhes de erros brutos, URLs, conteúdo do usuário ou tokens, aplicando um esquema pré-autorizado.

Melhorias:
- Normalizar os diagnósticos de sincronização para mensagens fixas contendo apenas id, timestamp e tipo, sanitizando os envelopes na leitura/gravação e durante a hidratação.
- Re-sanitizar os diagnósticos de sincronização com escopo de proprietário durante a exportação da conta, para que o JSON baixado não possa incluir campos legados sensíveis.
- Documentar o comportamento atualizado e o modelo de ameaça para diagnósticos de sincronização na documentação de privacidade e segurança.

Testes:
- Adicionar testes de unidade cobrindo a sanitização dos registros de sincronização, reescrita da hidratação legada, re-sanitização na exportação e aplicação do limite de retenção de 100 entradas.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Sanitize device-local sync diagnostics to remove raw error details and ensure only fixed, allowlisted outcomes are stored and exported.

Bug Fixes:
- Prevent legacy and new sync log entries from persisting raw error details, URLs, user content or tokens by enforcing an allowlisted schema.

Enhancements:
- Normalize sync diagnostics to fixed messages with only id, timestamp and type, sanitizing envelopes on read/write and during hydration.
- Re-sanitize owner-scoped sync diagnostics during account export so downloaded JSON cannot include legacy sensitive fields.
- Document the updated behavior and threat model for sync diagnostics in privacy and security docs.

Tests:
- Add unit tests covering sync log sanitization, legacy hydration rewriting, export re-sanitization and enforcement of the 100-entry retention cap.

</details>

</details>