### PR TITLE
docs: retire obsolete MVP checklist and March plans

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,7 @@ An exception applies only to its exact recorded scope. The default policy resume
 
 - Dated evidence remains under [`audits/`](audits/README.md), is immutable, and never authorizes current implementation.
 - Superseded desktop and broad-suite narratives remain searchable under [`archive/`](archive/README.md), outside the primary authority path.
-- The obsolete MVP checklist and March root plans are historical and owned by #134.
+- The obsolete MVP checklist and March planning records are preserved under [`archive/`](archive/README.md) and cannot authorize implementation.
 - Completed July agent plans/specs are historical and owned by #135.
 - Active taxonomy moves and link repair are deferred to #136, after authority and archive work stabilize.
 - Do not link historical plans or archive paths from Quick Start, Key Paths or issue templates as current authority.

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -10,6 +10,8 @@ This directory preserves superseded product narratives. Archived files remain se
 | --- | --- | --- |
 | `architecture/` | broad-suite and desktop-first architecture | [`architecture-overview.md`](../architecture-overview.md) and [`adr/0001-canonical-runtime.md`](../adr/0001-canonical-runtime.md) |
 | `implementation/` | historical implementation claims | [`mvp/canonical-mvp.md`](../mvp/canonical-mvp.md) and this repository's current code/tests |
+| `mvp/` | obsolete MVP execution checklist | [`mvp/canonical-mvp.md`](../mvp/canonical-mvp.md) and the open GitHub issue backlog |
+| `plans/` | completed or superseded March 2026 planning records | [`README.md`](../README.md), [`mvp/canonical-mvp.md`](../mvp/canonical-mvp.md), and the open GitHub issue backlog |
 | `product/` | broad-suite PRD v2.2 | [`mvp/canonical-mvp.md`](../mvp/canonical-mvp.md) and [`product/2026-07-16-product-positioning-brief.md`](../product/2026-07-16-product-positioning-brief.md) |
 | `release/` | desktop MVP readiness, release, checklist and backlog narratives | [`release-verification-ladder.md`](../release-verification-ladder.md) and [`mvp/canonical-mvp.md`](../mvp/canonical-mvp.md) |
 

--- a/docs/archive/mvp/implementation-checklist.md
+++ b/docs/archive/mvp/implementation-checklist.md
@@ -1,6 +1,11 @@
-# LifeOS MVP Implementation Checklist
+Status: HISTORICAL
+Authority: historical execution record only
+Snapshot date: 2026-03-19
+Current successor: `docs/mvp/canonical-mvp.md` and the open GitHub issue backlog
+Authorizes implementation: no
+Historical provenance: Paperclip architecture delivery plan in a machine-local workspace; the absolute path is intentionally not retained as authority
 
-Source of truth: `/home/pedro/.paperclip/instances/default/workspaces/aba66bcd-2a37-4871-9854-1b8106f3fe2a/plans/2026-03-19-lifeos-architecture-delivery-plan.md`
+# LifeOS MVP Implementation Checklist
 
 ## Product Boundary
 

--- a/docs/archive/plans/2026-03-19-mvp-boundary-audit.md
+++ b/docs/archive/plans/2026-03-19-mvp-boundary-audit.md
@@ -1,3 +1,9 @@
+Status: HISTORICAL
+Authority: historical decision memo only
+Snapshot date: 2026-03-19
+Current successor: `docs/mvp/canonical-mvp.md` and `docs/product/2026-07-16-product-positioning-brief.md`
+Authorizes implementation: no
+
 # LifeOS Product Audit: MVP Boundary, Scope Drift, and Docs Trust
 
 Date: 2026-03-19
@@ -251,4 +257,3 @@ Reason:
 3. `/mvp/admin` internal-only access control
 4. MVP status language and readiness truthfulness pass
 5. MVP API contract doc alignment
-

--- a/docs/archive/plans/2026-03-20-canonical-mvp-doc-rewrite.md
+++ b/docs/archive/plans/2026-03-20-canonical-mvp-doc-rewrite.md
@@ -1,3 +1,9 @@
+Status: HISTORICAL
+Authority: completed delivery record only
+Snapshot date: 2026-03-20
+Current successor: `docs/README.md` and `docs/mvp/canonical-mvp.md`
+Authorizes implementation: no
+
 # LifeOS Canonical MVP Doc Rewrite
 
 Date: 2026-03-20

--- a/docs/archive/plans/2026-03-20-wave-2-legacy-coupling-map.md
+++ b/docs/archive/plans/2026-03-20-wave-2-legacy-coupling-map.md
@@ -1,3 +1,9 @@
+Status: HISTORICAL
+Authority: historical proposal only
+Snapshot date: 2026-03-20
+Current successor: `docs/architecture-overview.md` and the open GitHub issue backlog
+Authorizes implementation: no
+
 # LifeOS Wave 2: Mapa de Acoplamento para Deleção de Legado
 
 Data: 2026-03-20

--- a/docs/archive/plans/2026-03-21-mvp-interface-quality-bar.md
+++ b/docs/archive/plans/2026-03-21-mvp-interface-quality-bar.md
@@ -1,3 +1,9 @@
+Status: HISTORICAL
+Authority: historical product/UX proposal only
+Snapshot date: 2026-03-21
+Current successor: `docs/mvp/canonical-mvp.md` and design-partner discovery issue #104
+Authorizes implementation: no
+
 # LifeOS MVP: Barra de Qualidade de Interface e Rubric de Decisão
 
 Data: 2026-03-21


### PR DESCRIPTION
## Problem

A completed checklist and four March planning records remained in active paths, including a machine-local Paperclip path presented as source of truth. Their unfinished items could be mistaken for authorized current work.

## Solution

- preserve the checklist and four plans under `docs/archive/**` with historical/non-authorizing metadata;
- replace the absolute Paperclip authority claim with portable historical provenance;
- keep original outcomes and proposal bodies intact;
- update archive and central documentation indexes;
- leave root `plans/` empty.

## Scope

Documentation only. No historical requirement was migrated into current scope and no product/runtime behavior changed.

## Verification

- root `plans/` contains zero files;
- five archived records satisfy status/non-authority metadata invariants;
- no active README/MVP/plan path contains an absolute Paperclip authority;
- 39 non-historical Markdown files have zero missing local link targets;
- all five moves are detected as Git renames (88–98% similarity);
- `git diff --check` clean;
- independent staged review passed.

## Risk and rollback

Low navigation risk; rollback is a clean revert. Archived items cannot authorize implementation or reopen work.

Closes #134

## Summary by Sourcery

Arquivar a checklist obsoleta de implementação do LifeOS MVP e os registros de planejamento de março de 2026 com metadados históricos explícitos e não autoritativos, e atualizar os índices de documentação central e de arquivo para referenciar seus novos locais e esclarecer seu status.

Documentation:
- Marcar a checklist de implementação do MVP e quatro documentos de planejamento de março de 2026 como registros históricos, com proveniência clara, sucessores e status não autoritativo.
- Mover a checklist obsoleta do MVP e os arquivos de planejamento de março para caminhos de arquivo estruturados em `docs/archive/`, deixando o diretório raiz `plans/` vazio para uso ativo futuro.
- Atualizar o README central e o índice de arquivos para referenciar o MVP arquivado e os documentos de planejamento, indicando que eles não podem autorizar a implementação atual.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Archive the obsolete LifeOS MVP implementation checklist and March 2026 planning records with explicit historical, non-authoritative metadata, and update central and archive documentation indexes to reference their new locations and clarify their status.

Documentation:
- Mark the MVP implementation checklist and four March 2026 planning documents as historical records with clear provenance, successors, and non-authoritative status.
- Move the obsolete MVP checklist and March planning files into structured archive paths under `docs/archive/`, leaving the root `plans/` directory empty for future active use.
- Update the central README and archive index to reference the archived MVP and planning documents and state that they cannot authorize current implementation.

</details>

Documentação:
- Marcar o checklist de implementação do MVP e quatro registros de planejamento de março de 2026 como documentos históricos, não autoritativos, com proveniência e sucessores claramente definidos.
- Mover o checklist obsoleto e os arquivos de planejamento para caminhos de arquivo estruturados sob `docs/archive/`, deixando o diretório raiz `plans/` vazio para uso ativo.
- Atualizar os índices README central e de arquivo para referenciar o MVP arquivado e os registros de planejamento, esclarecendo que eles não podem autorizar a implementação atual.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Arquivar a checklist obsoleta de implementação do LifeOS MVP e os registros de planejamento de março de 2026 com metadados históricos explícitos e não autoritativos, e atualizar os índices de documentação central e de arquivo para referenciar seus novos locais e esclarecer seu status.

Documentation:
- Marcar a checklist de implementação do MVP e quatro documentos de planejamento de março de 2026 como registros históricos, com proveniência clara, sucessores e status não autoritativo.
- Mover a checklist obsoleta do MVP e os arquivos de planejamento de março para caminhos de arquivo estruturados em `docs/archive/`, deixando o diretório raiz `plans/` vazio para uso ativo futuro.
- Atualizar o README central e o índice de arquivos para referenciar o MVP arquivado e os documentos de planejamento, indicando que eles não podem autorizar a implementação atual.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Archive the obsolete LifeOS MVP implementation checklist and March 2026 planning records with explicit historical, non-authoritative metadata, and update central and archive documentation indexes to reference their new locations and clarify their status.

Documentation:
- Mark the MVP implementation checklist and four March 2026 planning documents as historical records with clear provenance, successors, and non-authoritative status.
- Move the obsolete MVP checklist and March planning files into structured archive paths under `docs/archive/`, leaving the root `plans/` directory empty for future active use.
- Update the central README and archive index to reference the archived MVP and planning documents and state that they cannot authorize current implementation.

</details>

</details>