### PR TITLE
Keep the mobile dock clear of weekly-loop content

### DIFF
--- a/src/app/layout/AppLayout.test.tsx
+++ b/src/app/layout/AppLayout.test.tsx
@@ -13,7 +13,7 @@ vi.mock('@/features/onboarding/OnboardingModal', () => ({
 }));
 
 vi.mock('@/app/layout/NavigationSystem', () => ({
-  NavigationSystem: () => <nav>Navigation</nav>,
+  NavigationSystem: () => <nav aria-label="Navigation">Navigation</nav>,
 }));
 
 it('does not mount the legacy onboarding over the canonical web loop', async () => {
@@ -27,4 +27,21 @@ it('does not mount the legacy onboarding over the canonical web loop', async () 
   );
 
   expect(screen.queryByText('Legacy onboarding overlay')).not.toBeInTheDocument();
+});
+
+it('reserves mobile content clearance without a second fixed navigation wrapper', () => {
+  window.scrollTo = vi.fn();
+
+  const { container } = render(
+    <MemoryRouter>
+      <AppLayout />
+    </MemoryRouter>
+  );
+
+  const [, navigation] = screen.getAllByRole('navigation', { name: 'Navigation' });
+  expect(navigation.parentElement?.parentElement).not.toHaveClass('fixed');
+  expect(container.querySelector('main > div')).toHaveClass(
+    'pb-32',
+    'md:pb-0'
+  );
 });

--- a/src/app/layout/AppLayout.test.tsx
+++ b/src/app/layout/AppLayout.test.tsx
@@ -1,4 +1,4 @@
-import { expect, it, vi } from 'vitest';
+import { beforeEach, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -16,8 +16,11 @@ vi.mock('@/app/layout/NavigationSystem', () => ({
   NavigationSystem: () => <nav aria-label="Navigation">Navigation</nav>,
 }));
 
-it('does not mount the legacy onboarding over the canonical web loop', async () => {
+beforeEach(() => {
   window.scrollTo = vi.fn();
+});
+
+it('does not mount the legacy onboarding over the canonical web loop', async () => {
   localStorage.removeItem('life-os-onboarding-completed');
 
   render(
@@ -30,18 +33,16 @@ it('does not mount the legacy onboarding over the canonical web loop', async () 
 });
 
 it('reserves mobile content clearance without a second fixed navigation wrapper', () => {
-  window.scrollTo = vi.fn();
-
-  const { container } = render(
+  render(
     <MemoryRouter>
       <AppLayout />
     </MemoryRouter>
   );
 
-  const [, navigation] = screen.getAllByRole('navigation', { name: 'Navigation' });
-  expect(navigation.parentElement?.parentElement).not.toHaveClass('fixed');
-  expect(container.querySelector('main > div')).toHaveClass(
+  expect(screen.getByTestId('mobile-navigation-slot')).not.toHaveClass('fixed');
+  expect(screen.getByTestId('route-content')).toHaveClass(
     'pb-32',
     'md:pb-0'
   );
+  expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
 });

--- a/src/app/layout/AppLayout.tsx
+++ b/src/app/layout/AppLayout.tsx
@@ -57,15 +57,13 @@ export function AppLayout() {
             ) : null}
 
             {/* Sidebar Navigation - Always Visible on Desktop */}
-            <aside className="hidden lg:flex flex-col w-24 h-screen shrink-0 z-50">
+            <aside className="hidden md:flex flex-col w-24 h-screen shrink-0 z-50">
                 <NavigationSystem />
             </aside>
 
             {/* Mobile Navigation - Always Visible on Mobile */}
-            <div className="lg:hidden fixed bottom-0 left-0 right-0 z-50 p-4 pointer-events-none">
-                <div className="pointer-events-auto">
-                    <NavigationSystem />
-                </div>
+            <div className="md:hidden">
+                <NavigationSystem />
             </div>
 
             {/* Main Content Area */}
@@ -78,7 +76,7 @@ export function AppLayout() {
                         animate="animate"
                         exit="exit"
                         transition={pageTransition}
-                        className="w-full min-h-screen"
+                        className="w-full min-h-screen pb-32 md:pb-0"
                     >
                         <Outlet />
                     </motion.div>

--- a/src/app/layout/AppLayout.tsx
+++ b/src/app/layout/AppLayout.tsx
@@ -62,7 +62,7 @@ export function AppLayout() {
             </aside>
 
             {/* Mobile Navigation - Always Visible on Mobile */}
-            <div className="md:hidden">
+            <div className="md:hidden" data-testid="mobile-navigation-slot">
                 <NavigationSystem />
             </div>
 
@@ -76,6 +76,7 @@ export function AppLayout() {
                         animate="animate"
                         exit="exit"
                         transition={pageTransition}
+                        data-testid="route-content"
                         className="w-full min-h-screen pb-32 md:pb-0"
                     >
                         <Outlet />

--- a/src/features/mvp/pages/MvpWorkspacePage.tsx
+++ b/src/features/mvp/pages/MvpWorkspacePage.tsx
@@ -109,7 +109,7 @@ export function MvpWorkspacePage() {
   }
 
   return (
-    <main className="space-y-6 pb-24 md:pb-8">
+    <main className="space-y-6 md:pb-8">
       <header className="max-w-3xl space-y-2">
         <p className="text-sm font-medium text-primary">Your weekly loop</p>
         <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">A clear week starts with one next step.</h1>


### PR DESCRIPTION
Closes #153

## Why

The mobile navigation was fixed twice and route pages tried to compensate with their own bottom padding. That left onboarding, today, and reflection content under the dock and made the responsive boundary inconsistent.

## What changed

- make `NavigationSystem` the only fixed-position owner
- reserve mobile clearance once in `AppLayout`
- align sidebar/dock switching at 768 px (`md`)
- remove the weekly route-specific mobile compensation
- add a focused layout regression test

## Visual evidence

At 390x844, final content now ends at 716 px and the dock starts at 754 px on onboarding, weekly, today, and reflection: 38 px clear, zero overlap, zero horizontal overflow. Before overlap was 32 px, 0 px with only 6 px clearance, 66 px, and 16 px respectively.

Tablet 800x900 and desktop 1440x1000 retain the sidebar and hide the fixed dock. Reduced motion and visible keyboard focus were also checked. Visual verdict: 96/100, pass.

## Verification

- Vitest: 287/287 suites; 763 passed, 63 declared skips, 0 failed
- focused regression: 9/9 passed
- typecheck: passed
- lint: 0 errors (9 baseline warnings)
- web build: passed
- server build: passed
- canonical Playwright E2E: 1/1 passed
- independent review: no Critical findings; safe-area double counting corrected before final audit

TestSprite was not run because its current cases assert copy rather than layout geometry; direct Playwright viewport measurements cover this change.

## Scope

Layout-only. No copy, forms, auth, backend, navigation taxonomy, dependencies, or animation behavior changed.

## Summary by Sourcery

Unificar o padding do layout mobile e o comportamento de navegação para que o dock não se sobreponha mais ao conteúdo da página, ao mesmo tempo em que se ajusta o breakpoint da sidebar e se fortalecem os testes de layout.

Bug Fixes:
- Impedir que a navegação mobile se sobreponha ao conteúdo principal, reservando um padding inferior consistente no layout compartilhado em vez de sobrescritas por rota.

Enhancements:
- Fazer com que o `NavigationSystem` seja o único dono em posição fixa e remover o wrapper fixo extra da navegação mobile de `AppLayout`.
- Alterar o layout de desktop/sidebar para ser ativado a partir do breakpoint `md` em vez de `lg`, alinhando o comportamento de navegação entre os diferentes viewports.
- Atualizar o mock de landmark de navegação para incluir um rótulo acessível, permitindo uma segmentação de testes mais clara.

Tests:
- Estender os testes de `AppLayout` com um caso de regressão específico que verifique a folga do conteúdo mobile e o comportamento esperado de padding.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify mobile layout padding and navigation behavior so that the dock no longer overlaps page content, while shifting the sidebar breakpoint and strengthening layout tests.

Bug Fixes:
- Prevent mobile navigation from overlapping main content by reserving a consistent bottom padding in the shared layout rather than per-route overrides.

Enhancements:
- Make `NavigationSystem` the sole fixed-position owner and remove the extra fixed wrapper from `AppLayout`'s mobile navigation.
- Switch the desktop/sidebar layout to activate from the `md` breakpoint instead of `lg`, aligning navigation behavior across viewports.
- Update the navigation landmark mock to include an accessible label for clearer test targeting.

Tests:
- Extend `AppLayout` tests with a focused regression case that verifies mobile content clearance and expected padding behavior.

</details>

Correções de bug:
- Impedir que a navegação mobile se sobreponha ao conteúdo principal, reservando um padding inferior consistente no layout compartilhado.

Melhorias:
- Unificar o comportamento da navegação entre breakpoints, passando a usar o layout de sidebar a partir do breakpoint `md` em vez de `lg`.
- Simplificar a estrutura de navegação para que `NavigationSystem` seja responsável pelo posicionamento fixo, enquanto `AppLayout` fornece apenas o padding responsivo.
- Adicionar um teste de regressão focado para garantir que a área livre do conteúdo em mobile seja preservada.

Testes:
- Estender os testes de `AppLayout` para verificar o comportamento de clearance em mobile e atualizar a rotulagem de `role` de navegação para acessibilidade.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unificar o padding do layout mobile e o comportamento de navegação para que o dock não se sobreponha mais ao conteúdo da página, ao mesmo tempo em que se ajusta o breakpoint da sidebar e se fortalecem os testes de layout.

Bug Fixes:
- Impedir que a navegação mobile se sobreponha ao conteúdo principal, reservando um padding inferior consistente no layout compartilhado em vez de sobrescritas por rota.

Enhancements:
- Fazer com que o `NavigationSystem` seja o único dono em posição fixa e remover o wrapper fixo extra da navegação mobile de `AppLayout`.
- Alterar o layout de desktop/sidebar para ser ativado a partir do breakpoint `md` em vez de `lg`, alinhando o comportamento de navegação entre os diferentes viewports.
- Atualizar o mock de landmark de navegação para incluir um rótulo acessível, permitindo uma segmentação de testes mais clara.

Tests:
- Estender os testes de `AppLayout` com um caso de regressão específico que verifique a folga do conteúdo mobile e o comportamento esperado de padding.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify mobile layout padding and navigation behavior so that the dock no longer overlaps page content, while shifting the sidebar breakpoint and strengthening layout tests.

Bug Fixes:
- Prevent mobile navigation from overlapping main content by reserving a consistent bottom padding in the shared layout rather than per-route overrides.

Enhancements:
- Make `NavigationSystem` the sole fixed-position owner and remove the extra fixed wrapper from `AppLayout`'s mobile navigation.
- Switch the desktop/sidebar layout to activate from the `md` breakpoint instead of `lg`, aligning navigation behavior across viewports.
- Update the navigation landmark mock to include an accessible label for clearer test targeting.

Tests:
- Extend `AppLayout` tests with a focused regression case that verifies mobile content clearance and expected padding behavior.

</details>

</details>